### PR TITLE
README: Add "agents" to straight installation

### DIFF
--- a/README.org
+++ b/README.org
@@ -49,7 +49,8 @@ Or from =use-package= (Emacs 30+):
 #+html: </summary>
 
 #+begin_src emacs-lisp
-(straight-use-package (gptel-agent :host github :repo "karthink/gptel-agent"))
+(straight-use-package (gptel-agent :host github :repo "karthink/gptel-agent"
+                                   :files (:defaults "agents")))
 #+end_src
 
 #+begin_src emacs-lisp
@@ -60,7 +61,8 @@ Or from =use-package=:
 
 #+begin_src emacs-lisp
 (use-package gptel-agent
-  :straight (:host github :repo "karthink/gptel-agent") ;use :ensure for Elpaca
+  :straight (:host github :repo "karthink/gptel-agent"
+                   :files (:defaults "agents")) ;use :ensure for Elpaca
   :config (gptel-agent-update))         ;Read files from agents directories
 #+end_src
 


### PR DESCRIPTION
When straight builds the package, it doesn't link the "agents" folder unless specified in the recipe. Adding that line to the README file.