### PR TITLE
fix. use default-directory when not in a project

### DIFF
--- a/gptel-agent.el
+++ b/gptel-agent.el
@@ -372,8 +372,9 @@ this session, which defaults to the default `gptel-agent'."
   (interactive
    (list (if current-prefix-arg
              (funcall project-prompter)
-           (or (project-root (project-current))
-               default-directory))
+           (if-let ((proj (project-current)))
+               (project-root proj)
+             default-directory))
          'gptel-agent))
   (let ((gptel-buf
          (gptel (generate-new-buffer-name


### PR DESCRIPTION
Currently, `gptel-agent` signals an error if there is no current project as defined by project.el. That is because, in that case, `(project-current)` evaluates to `nil` and this `nil` is passed `project-root`, which signals an error.

This commit fixes this, so that `gptel-agent` defaults to using `default-directory` in the case where `(project-current)` evaluates to nil.
