### PR TITLE
Add :type for `new_str` parameter in `Insert` tool

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -1454,7 +1454,8 @@ specific location with no changes to the surrounding context."
 - -1 to insert at the end."
            :type integer)
          ( :name "new_str"
-           :description "String to insert at `line_number`."))
+           :description "String to insert at `line_number`."
+           :type string))
  :category "gptel-agent"
  :confirm t
  :include t)


### PR DESCRIPTION
When I use gptel-agent with ollama and the Kimi K2 models, I got a 

```
"HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json; charset=utf-8\r\nDate: Mon, 08 Dec 2025 20:32:45 GMT\r\nContent-Length: 87\r\n\r"
```

but not when I used the Kimi K2 model without the `gptel-agent` tools. I narrowed it down to the missing `:type` of the `new_str` parameter. With this change, gptel-agent (and the tools) seem to work now with the Kimi K2 models.