### PR TITLE
fix: parse context as list when loading presets from org mode

### DIFF
--- a/gptel-agent.el
+++ b/gptel-agent.el
@@ -335,6 +335,7 @@ Signals an error if:
                    (value (cdr pair)))
 
               (pcase key-sym
+                (:context (setq value (split-string value)))
                 (:tools (setq value (split-string value))))
 
               ;; Skip CATEGORY property (added automatically by Org)


### PR DESCRIPTION
allow setting gptel-context to a list of files to include, just like tools