### PR TITLE
Set indent-tabs-mode to nil for this repository

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((nil . ((indent-tabs-mode . nil))))


### PR DESCRIPTION
The code in this repository seems to be indented using spaces, but Emacs defaults to indenting with tabs. Perhaps a `.dir-locals.el` setting `indent-tabs-mode` to `nil` could be added to the repository?