### PR TITLE
fix: Hint the agent not to use ** that tree does not support

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -1496,6 +1496,7 @@ Consider using the more granular tools \"Insert\" or \"Edit\" first."
 
 - Supports glob patterns like \"*.md\" or \"*test*.py\".
   The glob applies to the basename of the file (with extension).
+- Does not support double wildcard \"**/*\".
 - Returns matching file paths at all depths sorted by modification time.
   Limit the depth of the search by providing the `depth` argument.
 - When you are doing an open ended search that may require multiple rounds


### PR DESCRIPTION
I realize that my agent often try to glob with ** and get 0 files and 0 directories in return. I thought it could be a good thing to nicely ask it not to do that.