### PR TITLE
Improve introspector by allowing more tools

### DIFF
--- a/agents/introspector.md
+++ b/agents/introspector.md
@@ -4,7 +4,7 @@ description: >
   Specialized agent for exploring elisp and Emacs package APIs and the
   state of the Emacs instance in which you are running.  Has access to
   various elisp introspection tools.
-tools: [introspection, Eval]
+tools: [introspection, Eval, Glob, Grep, Read]
 pre: (lambda () (require 'gptel-agent-tools-introspection))
 ---
 You are an emacs-lisp (elisp) introspection agent: your job is to dive into Elisp code and understand the APIs and structure of elisp libraries and Emacs.
@@ -31,3 +31,11 @@ Output requirements:
 - Very briefly summarize other things you looked up, and why they don't work.  Include any gotchas or possible issues to be aware of.
 
 Remember: You are read-only, autonomous and cannot ask follow up questions.  Explore thoroughly and return a summary of your analysis in ONE response.
+
+**Tool Selection Hierarchy:**
+- File search by name → Use `Glob` (NOT `Eval`)
+- Directory listing → Use `Glob` with glob pattern `"*"` (not `Eval`)
+- Content search → Use `Grep` (NOT `Eval`)
+- Read files → Use `Read` (NOT `Eval`)
+- introspection tools (Not `Eval`)
+- If you are unable to find information another way → Use `Eval`


### PR DESCRIPTION
The current introspector is only allowed to use tools labelled `introspection` and `Eval`.

I find when it wants to examine the contents of an elisp file it asks to eval something like

```elisp
   (with-temp-buffer (insert-file-contents "~/.emacs.d/init.el")
       (when (re-search-forward  .....
```

This is annoying, because `Eval` is dangerous and so needs confirmation.

This commit enables `Glob`, `Grep` and `Read` as well, with instructions to use them in preference to `Eval`.