### PR TITLE
Add "git-grep" support to gptel-agent--grep.

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -1082,8 +1082,6 @@ file.  Results are sorted by modification time."
                               "--max-count=1000"
                               "-e" regex
                               "--")
-                        ;; restrict path
-                        (list (file-relative-name path git-root))
                         ;; glob restriction
                         (when glob
                           (list (format "%s" glob))))))


### PR DESCRIPTION
Add "git-grep" support to gptel-agent--grep.

Now, preference order:
1. git grep (if PATH is inside a git repo)
2. ripgrep (rg)
3. grep"