### PR TITLE
Ensure youtube transcript is utf-8 encoded

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -380,6 +380,8 @@ COUNT is the number of results to return (default 5)."
   "Parse YouTube caption XML-STRING and return DOM."
   (with-temp-buffer
     (insert xml-string)
+    (set-buffer-multibyte t)
+    (decode-coding-region (point-min) (point-max) 'utf-8)
     (goto-char (point-min))
     ;; Clean up the XML
     (dolist (reps '(("\n" . " ")


### PR DESCRIPTION
With this [video](https://www.youtube.com/watch?v=-xNq_wJHsls) I get raw bytes in the transcript, as a results the xml parser cannot parse the transcript. 

Not entirely sure this is the right fix though. It works for this case though. 