### PR TITLE
Update README with arxiv-explorer agent details

### DIFF
--- a/README.org
+++ b/README.org
@@ -167,12 +167,12 @@ You can specify the agent name, description and tools used as YAML front-matter
 in a Markdown file, followed by the system prompt:
 
 #+begin_src markdown
-----
+---
 name: arxiv-explorer
 description: Searches ArXiv and parses results
 tools: [mcp-arxiv, WebSearch]
 pre: (lambda () (gptel-mcp-connect '(arxiv) 'sync))
-----
+---
 
 You are a specialized research agent with access to ArXiv.  Your purpose is to
 search for and gather information efficiently.


### PR DESCRIPTION
## Issue with `arxiv-explorer`

The `README.org` file uses `----` (4 dashes) instead of `---` (3 dashes), so the YAML frontmatter isn't being parsed. The regex in `gptel-agent-parse-markdown-frontmatter` expects exactly `^---[ \t]*$`.

**Fix:** Change the delimiter from `----` to `---`