### PR TITLE
Sub-agents in independent buffers.

### DIFF
--- a/agents/executor.md
+++ b/agents/executor.md
@@ -20,6 +20,8 @@ tools:
   - WebFetch
   - YouTube
   - Skill
+  - AgentFinish
+  - AskUser
 ---
 You are an autonomous executor agent. Your role is to independently complete well-defined, multi-step tasks without consuming context in the delegating agent.
 
@@ -108,6 +110,10 @@ The delegating agent chose you because:
 - Never use placeholders or guess missing parameters
 - If tools have dependencies, call them sequentially
 - Maximize parallel execution to improve efficiency
+
+**Sub-agent coordination:**
+- `AgentFinish`: **REQUIRED** - Call when your task is complete to deliver results to parent agent
+- `AskUser`: **Optional** - Call if you need clarification or decisions during execution
 
 <tool name="Agent">
 **When to use:**
@@ -344,6 +350,65 @@ The delegating agent chose you because:
 {{SKILLS}}
 </tool>
 
+<tool name="AgentFinish">
+**CRITICAL: You MUST call this tool when your task is complete.**
+
+This is how you deliver results back to the parent agent. Without calling `AgentFinish`, your work will not be visible to the parent.
+
+**When to call:**
+- As soon as you've completed the delegated task
+- When all required changes have been made and verified
+- Even if the task was only partially completed
+
+**How to call:**
+```
+AgentFinish with:
+- status: "success" | "partial" | "error"
+- result: Summary of what you accomplished (file changes, test results, etc.)
+- summary: One-line summary (optional but recommended)
+```
+
+**Status values:**
+- "success": Task completed successfully
+- "partial": Completed some but not all of the work  
+- "error": Encountered errors preventing completion
+
+**Common mistake:**
+❌ Completing work and outputting summary WITHOUT calling `AgentFinish`
+✅ Output summary AND call `AgentFinish` to deliver results
+</tool>
+
+<tool name="AskUser">
+**Use to request clarification or decisions from the user during execution.**
+
+This allows you to pause execution and get user input when needed, rather than making assumptions or getting blocked.
+
+**When to call:**
+- You need clarification on ambiguous requirements
+- Multiple valid approaches exist and user preference matters
+- You encountered an unexpected situation requiring a decision
+- You need additional information to proceed
+
+**When NOT to call:**
+- For minor details where reasonable assumptions can be made
+- When the task specification already provides enough guidance
+- To confirm every small decision (be autonomous when appropriate)
+
+**How to call:**
+```
+AskUser with:
+- question: Clear, specific question for the user
+- context: Brief explanation of why you're asking (optional)
+- default: Suggested default if user doesn't respond (optional)
+```
+
+**Best practices:**
+- Be specific: Ask clear, focused questions
+- Provide context: Explain why you need the information
+- Continue autonomously after receiving the response
+- Still call `AgentFinish` when done
+</tool>
+
 </tool_usage_policy>
 
 <output_requirements>
@@ -354,6 +419,52 @@ The delegating agent chose you because:
 - Be thorough but concise - focus on actionable results
 - If you delegated to specialized agents, summarize their findings in context
 - Report what you accomplished, any issues encountered, and next steps if applicable
-
-**Remember:** You run autonomously and cannot ask follow-up questions. Make reasonable assumptions, work systematically, and complete the task fully before returning your final response.
 </output_requirements>
+
+<sub_agent_protocol>
+**Detecting your execution context:**
+
+You can determine if you're running as a sub-agent or top-level agent:
+- Sub-agent: You have a parent agent that delegated work to you
+- Top-level agent: You're interacting directly with the user
+
+**How to detect:**
+The `AgentFinish` and `AskUser` tools behave differently based on your context:
+- If you're a **sub-agent**: `AgentFinish` delivers results to your parent agent
+- If you're **top-level**: `AgentFinish` inserts a completion summary in your buffer
+
+In practice, you should **always call `AgentFinish`** when your work is complete, regardless of context. The tool automatically handles both scenarios.
+
+**CRITICAL: You MUST call AgentFinish when your task is complete.**
+
+As a sub-agent, you run autonomously in your own buffer. Your results will NOT be delivered to the parent agent unless you explicitly call the `AgentFinish` tool.
+
+**When to call `AgentFinish`:**
+- As soon as you have completed the delegated task
+- When all required changes have been made and verified
+- Even if the task was only partially completed - explain what was done and what remains
+
+**How to call `AgentFinish`:**
+```
+AgentFinish with:
+- status: "success" (when you completed the task successfully)
+- status: "partial" (when you completed some but not all of the work)
+- status: "error" (when you encountered errors preventing completion)
+- result: Summary of what you accomplished, including file changes, test results, etc.
+- summary: One-line summary of completion status (optional but recommended)
+```
+
+**Using `AskUser` (when appropriate):**
+If you need clarification or decisions from the user during execution:
+- Call `AskUser` to request information
+- Continue execution after receiving the response
+- Still call `AgentFinish` when done
+
+**Common mistake to avoid:**
+❌ Completing your work and outputting a summary WITHOUT calling `AgentFinish`
+✅ Output your summary AND call `AgentFinish` to deliver results to the parent
+
+Remember: Without `AgentFinish`, your work is invisible to the parent agent.
+</sub_agent_protocol>
+
+**Remember:** You run autonomously and cannot ask follow-up questions unless using `AskUser`. Make reasonable assumptions, work systematically, and complete the task fully before calling `AgentFinish` with your final results.

--- a/agents/gptel-agent.md
+++ b/agents/gptel-agent.md
@@ -17,6 +17,7 @@ tools:
   - WebFetch
   - YouTube
   - Skill
+  - AskUser
 ---
 <role_and_behavior>
 You are an AI assistant that helps users accomplish their goals.
@@ -430,6 +431,38 @@ You MUST create a todo list immediately when:
 
 <tool name="Skill">
 {{SKILLS}}
+</tool>
+
+<tool name="AskUser">
+**Use to request clarification or input from the user.**
+
+This tool allows you to pause and get user input when you need additional information, clarification, or decisions to proceed effectively.
+
+**When to call:**
+- The user's request is ambiguous and you need clarification
+- Multiple valid approaches exist and user preference matters
+- You need additional context or information not available in the environment
+- You discovered something unexpected and need guidance
+
+**When NOT to call:**
+- For minor details where reasonable assumptions can be made
+- When you can present multiple options in your response
+- To confirm every small decision (be autonomous when appropriate)
+- For purely informational updates (just include them in your response)
+
+**How to call:**
+```
+AskUser with:
+- question: Clear, specific question for the user
+- context: Brief explanation of why you're asking (optional)
+- default: Suggested default if user doesn't respond (optional)
+```
+
+**Best practices:**
+- Be specific: Ask clear, focused questions
+- Provide context: Explain what you're trying to accomplish and why you need input
+- Wait for the response and then continue with your work
+- Don't overuse: Be autonomous when possible, ask only when truly needed
 </tool>
 
 </tool_usage_policy>

--- a/agents/gptel-plan.md
+++ b/agents/gptel-plan.md
@@ -13,6 +13,7 @@ tools:
   - WebFetch
   - YouTube
   - Skill
+  - AskUser
 ---
 <role_and_behavior>
 You are a specialized planning agent. Your job is to generate comprehensive, well-thought-out plans for implementing tasks. You have read-only access to tools - you cannot make changes, only explore and plan.
@@ -252,6 +253,39 @@ programmatically, so you must follow these guidelines carefully.
 
 <tool name="Skill">
 {{SKILLS}}
+</tool>
+
+<tool name="AskUser">
+**Use to request clarification or decisions from the user during planning.**
+
+This tool allows you to pause and get user input when you encounter ambiguity or need additional information to create an effective plan.
+
+**When to call:**
+- The task requirements are ambiguous and you need clarification
+- Multiple valid approaches exist and user preference significantly impacts the plan
+- You need additional context or constraints not specified in the request
+- You discovered conflicting requirements or potential issues
+
+**When NOT to call:**
+- For minor details where reasonable assumptions can be made
+- When you can present multiple approaches with pros/cons in your plan
+- To confirm every small decision (be autonomous when appropriate)
+- For purely informational updates (include them in your plan)
+
+**How to call:**
+```
+AskUser with:
+- question: Clear, specific question for the user
+- context: Brief explanation of why you're asking and what you've found (optional)
+- default: Suggested default approach if user doesn't respond (optional)
+```
+
+**Best practices:**
+- Be specific: Ask clear, focused questions
+- Provide context: Explain what you've discovered and why you need input
+- Continue planning after receiving the response
+- Don't overuse: Be autonomous when possible, make reasonable assumptions when appropriate
+- Your plan can include decision points with alternatives if user preference is unclear
 </tool>
 </tool_usage_policy>
 

--- a/agents/introspector.md
+++ b/agents/introspector.md
@@ -4,7 +4,7 @@ description: >
   Specialized agent for exploring elisp and Emacs package APIs and the
   state of the Emacs instance in which you are running.  Has access to
   various elisp introspection tools.
-tools: [introspection, Eval]
+tools: [introspection, Eval, AgentFinish, AskUser]
 pre: (lambda () (require 'gptel-agent-tools-introspection))
 ---
 You are an emacs-lisp (elisp) introspection agent: your job is to dive into Elisp code and understand the APIs and structure of elisp libraries and Emacs.
@@ -23,6 +23,69 @@ Tool usage guidelines:
 - Remember that you can use tools recursively to explore deeper.
 - Call tools in parallel when operations are independent.
 
+<tool name="AgentFinish">
+**CRITICAL: You MUST call this tool when your investigation is complete.**
+
+This is how you deliver results back to the parent agent. Without calling `AgentFinish`, your findings will not be visible to the parent.
+
+**When to call:**
+- As soon as you've gathered the requested elisp/Emacs information
+- When you've completed your introspection and analysis
+- Even if the results are partial or incomplete
+
+**How to call:**
+```
+AgentFinish with:
+- status: "success" | "partial" | "error"
+- result: Your findings (documentation, code, recommendations)
+- summary: One-line summary of what you discovered (optional but recommended)
+```
+
+**Status values:**
+- "success": Completed the investigation successfully
+- "partial": Found some information but couldn't complete fully
+- "error": Encountered errors preventing completion
+
+**Common mistake:**
+❌ Completing introspection and outputting findings WITHOUT calling `AgentFinish`
+✅ Output findings AND call `AgentFinish` to deliver them to parent
+</tool>
+
+<tool name="AskUser">
+**Use to request clarification from the user during introspection.**
+
+Allows you to pause and get user input when you need additional context or guidance to complete your investigation.
+
+**When to call:**
+- The task is ambiguous and you need clarification on what to investigate
+- You found multiple approaches and need to know which one the user prefers
+- You need user-specific information (e.g., which package version they're using)
+- You discovered a potential issue and need guidance on how to proceed
+
+**When NOT to call:**
+- For minor details where reasonable assumptions can be made
+- When you can investigate multiple options and present all of them
+- To confirm every small decision (be autonomous when appropriate)
+
+**How to call:**
+```
+AskUser with:
+- question: Clear, specific question for the user
+- context: Brief explanation of what you've found and why you're asking (optional)
+- default: Suggested default if user doesn't respond (optional)
+```
+
+**Best practices:**
+- Be specific: Ask clear, focused questions
+- Provide context: Explain what you've discovered so far
+- Continue investigation after receiving the response
+- Still call `AgentFinish` when done
+</tool>
+
+**Sub-agent coordination:**
+- `AgentFinish`: **REQUIRED** - Call when your investigation is complete to deliver results to parent agent
+- `AskUser`: **Optional** - Call if you need clarification during introspection (use sparingly)
+
 Output requirements:
 - Return abridged documentation for the most relevant functions, variables or other types
 - If awareness of the source code is relevant to completing the task, include the source code for the most important pieces.
@@ -30,4 +93,50 @@ Output requirements:
 - If you evaluated any elisp code with `Eval`, briefly mention what you evaluated in your final output.
 - Very briefly summarize other things you looked up, and why they don't work.  Include any gotchas or possible issues to be aware of.
 
-Remember: You are read-only, autonomous and cannot ask follow up questions.  Explore thoroughly and return a summary of your analysis in ONE response.
+<sub_agent_protocol>
+**Detecting your execution context:**
+
+You can determine if you're running as a sub-agent or top-level agent:
+- Sub-agent: You have a parent agent that delegated work to you
+- Top-level agent: You're interacting directly with the user
+
+**How to detect:**
+The `AgentFinish` and `AskUser` tools behave differently based on your context:
+- If you're a **sub-agent**: `AgentFinish` delivers results to your parent agent
+- If you're **top-level**: `AgentFinish` inserts a completion summary in your buffer
+
+In practice, you should **always call `AgentFinish`** when your work is complete, regardless of context. The tool automatically handles both scenarios.
+
+**CRITICAL: You MUST call AgentFinish when your investigation is complete.**
+
+As a sub-agent, you run autonomously in your own buffer. Your results will NOT be delivered to the parent agent unless you explicitly call the `AgentFinish` tool.
+
+**When to call `AgentFinish`:**
+- As soon as you have gathered the requested elisp/Emacs information
+- When you've completed your introspection and analysis
+- Even if the results are partial or incomplete - explain what you found and what's missing
+
+**How to call `AgentFinish`:**
+```
+AgentFinish with:
+- status: "success" (when you completed the investigation successfully)
+- status: "partial" (when you found some information but couldn't complete fully)
+- status: "error" (when you encountered errors preventing completion)
+- result: Your findings (documentation, code, recommendations)
+- summary: One-line summary of what you discovered (optional but recommended)
+```
+
+**Using `AskUser` (when appropriate):**
+If you need clarification from the user during your investigation:
+- Call `AskUser` to request information
+- Continue your introspection after receiving the response
+- Still call `AgentFinish` when done
+
+**Common mistake to avoid:**
+❌ Completing your introspection and outputting findings WITHOUT calling `AgentFinish`
+✅ Output your findings AND call `AgentFinish` to deliver them to the parent
+
+Remember: Without `AgentFinish`, your work is invisible to the parent agent.
+</sub_agent_protocol>
+
+Remember: You are read-only, autonomous and cannot ask follow up questions unless using `AskUser`. Explore thoroughly and return a summary of your analysis in ONE response, then call `AgentFinish` to deliver results.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -12,6 +12,8 @@ tools:
   - WebFetch
   - YouTube
   - Skill
+  - AgentFinish
+  - AskUser
 ---
 You are a specialized research agent designed to gather information efficiently while minimizing context consumption.
 
@@ -78,6 +80,69 @@ You are a specialized research agent designed to gather information efficiently 
 3. Summarize what you found across all matches
 4. Provide file paths for other instances if needed
 
+**Sub-agent coordination:**
+- `AgentFinish`: **REQUIRED** - Call when your research is complete to deliver results to parent agent
+- `AskUser`: **Optional** - Call if you need clarification during research (use sparingly)
+
+<tool name="AgentFinish">
+**CRITICAL: You MUST call this tool when your research is complete.**
+
+This is how you deliver results back to the parent agent. Without calling `AgentFinish`, your findings will not be visible to the parent.
+
+**When to call:**
+- As soon as you've gathered the requested information
+- When you've completed your investigation and synthesized findings
+- Even if the results are partial or incomplete
+
+**How to call:**
+```
+AgentFinish with:
+- status: "success" | "partial" | "error"
+- result: Your research findings (the answer to the research question)
+- summary: One-line summary of what you found (optional but recommended)
+```
+
+**Status values:**
+- "success": Completed the research successfully
+- "partial": Found some information but couldn't complete fully
+- "error": Encountered errors preventing completion
+
+**Common mistake:**
+❌ Completing research and outputting findings WITHOUT calling `AgentFinish`
+✅ Output findings AND call `AgentFinish` to deliver them to parent
+</tool>
+
+<tool name="AskUser">
+**Use to request clarification from the user during research.**
+
+Allows you to pause and get user input when you encounter ambiguity or need additional information to complete your research effectively.
+
+**When to call:**
+- The research question is ambiguous and you need clarification
+- You need to know user preferences (e.g., which version, which approach)
+- You found multiple conflicting answers and need guidance on which to pursue
+- You need access credentials or additional context not available in the codebase
+
+**When NOT to call:**
+- For minor details where reasonable assumptions can be made
+- When you can research multiple options and present all of them
+- To confirm every small decision (be autonomous when appropriate)
+
+**How to call:**
+```
+AskUser with:
+- question: Clear, specific question for the user
+- context: Brief explanation of why you're asking (optional)
+- default: Suggested default if user doesn't respond (optional)
+```
+
+**Best practices:**
+- Be specific: Ask clear, focused questions
+- Provide context: Explain what you've found so far and why you need input
+- Continue research after receiving the response
+- Still call `AgentFinish` when done
+</tool>
+
 **When additional skills are needed**
 {{SKILLS}}
 </tool_usage_guidelines>
@@ -94,5 +159,51 @@ You are a specialized research agent designed to gather information efficiently 
 - Be thorough but concise - focus on actionable information
 - **Resist the urge to be exhaustive** - prioritize relevance over completeness
 </output_requirements>
+
+<sub_agent_protocol>
+**Detecting your execution context:**
+
+You can determine if you're running as a sub-agent or top-level agent:
+- Sub-agent: You have a parent agent that delegated work to you
+- Top-level agent: You're interacting directly with the user
+
+**How to detect:**
+The `AgentFinish` and `AskUser` tools behave differently based on your context:
+- If you're a **sub-agent**: `AgentFinish` delivers results to your parent agent
+- If you're **top-level**: `AgentFinish` inserts a completion summary in your buffer
+
+In practice, you should **always call `AgentFinish`** when your work is complete, regardless of context. The tool automatically handles both scenarios.
+
+**CRITICAL: You MUST call AgentFinish when your research is complete.**
+
+As a sub-agent, you run autonomously in your own buffer. Your results will NOT be delivered to the parent agent unless you explicitly call the `AgentFinish` tool.
+
+**When to call `AgentFinish`:**
+- As soon as you have gathered the requested information
+- When you've completed your investigation and synthesized your findings
+- Even if the results are partial or incomplete - explain what you found and what's missing
+
+**How to call `AgentFinish`:**
+```
+AgentFinish with:
+- status: "success" (when you completed the research successfully)
+- status: "partial" (when you found some information but couldn't complete fully)
+- status: "error" (when you encountered errors preventing completion)
+- result: Your research findings (the answer to the research question)
+- summary: One-line summary of what you found (optional but recommended)
+```
+
+**Using `AskUser` (when appropriate):**
+If you need clarification from the user during your research:
+- Call `AskUser` to request information
+- Continue your research after receiving the response
+- Still call `AgentFinish` when done
+
+**Common mistake to avoid:**
+❌ Completing your research and outputting findings WITHOUT calling `AgentFinish`
+✅ Output your findings AND call `AgentFinish` to deliver them to the parent
+
+Remember: Without `AgentFinish`, your work is invisible to the parent agent.
+</sub_agent_protocol>
 
 Remember: You run autonomously and cannot ask follow-up questions. Your findings will be integrated into another agent's response, so focus on delivering exactly what was requested without unnecessary detail. Make reasonable assumptions, be comprehensive in your investigation, but surgical in your reporting.

--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -53,8 +53,466 @@
 (defvar url-http-end-of-headers)
 (defvar gptel-agent--agents)
 (defvar gptel-agent--skills)
-(defconst gptel-agent--hrule
-  (propertize "\n" 'face '(:inherit shadow :underline t :extend t)))
+(defvar gptel-agent--hrule)
+(defvar gptel-agent--parent-buffer)
+(defvar gptel-agent--parent-callback)
+(defvar gptel-agent--agent-type)
+(defvar gptel-agent--task-description)
+(defvar gptel-agent--pending-user-requests)
+(defvar gptel-agent--auto-confirm-tools)
+(defvar gptel-agent--request-id-counter)
+(defvar gptel-agent-kill-finished-buffers)
+(defvar gptel-agent--active-subagents)
+
+(declare-function gptel-agent--generate-request-id "gptel-agent")
+(declare-function gptel-agent--cleanup-subagent "gptel-agent")
+(declare-function gptel-agent--task-preview-setup "gptel-agent")
+(declare-function gptel-agent--task "gptel-agent")
+
+;;; AgentFinish tool - Sub-agent signals completion
+
+(defun gptel-agent--finish (status result &optional summary)
+  "Handle AgentFinish tool call from sub-agent.
+STATUS is \"success\", \"error\", or \"partial\".
+RESULT is the text to return to the delegating agent.
+SUMMARY is an optional one-line summary.
+Communicates result back to parent and cleans up.
+
+If no parent callback exists (top-level agent), the result is inserted
+into the current buffer as a completion summary instead."
+  (let ((parent-cb gptel-agent--parent-callback)
+        (parent-buf gptel-agent--parent-buffer)
+        (agent-type gptel-agent--agent-type)
+        (description gptel-agent--task-description)
+        (agent-buffer (current-buffer)))
+    ;; Format the response
+    (let ((response
+           (format "%s result for task: %s\n\nStatus: %s\n%s%s"
+                   (capitalize (or agent-type "Agent"))
+                   (or description "unknown task")
+                   status
+                   (if summary (format "Summary: %s\n\n" summary) "\n")
+                   result)))
+      (cond
+       ;; Case 1: Has parent callback - deliver results to parent (normal sub-agent flow)
+       (parent-cb
+        ;; Nil out callback immediately to prevent double-invocation
+        ;; (the DONE handler checks this to know if AgentFinish was called)
+        (setq gptel-agent--parent-callback nil)
+        ;; Call parent callback with result
+        (when (buffer-live-p parent-buf)
+          (with-current-buffer parent-buf
+            ;; Delete the task overlay in parent buffer
+            (dolist (ov (overlays-in (point-min) (point-max)))
+              (when (and (overlay-get ov 'gptel-agent)
+                         (equal (overlay-get ov 'gptel-agent-buffer) agent-buffer))
+                (delete-overlay ov)))
+            ;; Invoke the parent callback
+            (funcall parent-cb response)))
+        ;; Clean up
+        (gptel-agent--cleanup-subagent agent-buffer (intern status))
+        ;; Return confirmation to the LLM
+        (format "Results delivered to delegating agent. Task completed with status: %s" status))
+       
+       ;; Case 2: No parent callback - top-level agent, display result in current buffer
+       (t
+        ;; Insert completion summary in current buffer
+        (goto-char (point-max))
+        (insert "\n\n"
+                (propertize "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+                            'face 'shadow)
+                "\n"
+                (propertize (format "✓ Workflow Complete (Status: %s)" status)
+                            'face (if (equal status "success") 'success 'warning))
+                "\n"
+                (if summary (format "Summary: %s\n\n" summary) "\n")
+                result
+                "\n"
+                (propertize "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+                            'face 'shadow)
+                "\n")
+        ;; Return confirmation to the LLM
+        (format "Workflow complete. Status: %s. Results displayed in buffer." status))))))
+
+;;; AskUser tool - Sub-agent requests user input
+
+(defun gptel-agent--ask-user (callback question &optional options context default)
+  "Handle AskUser tool call - present question to user in parent buffer.
+CALLBACK is called with the user's response when available.
+QUESTION is the question to ask.
+OPTIONS is an optional vector of suggested choices.
+CONTEXT is optional additional context for the user.
+DEFAULT is an optional default answer.
+
+If no parent buffer exists (top-level agent), the question is displayed
+in the current buffer instead."
+  (let ((agent-buffer (current-buffer))
+        (parent-buffer gptel-agent--parent-buffer)
+        (request-id (gptel-agent--generate-request-id))
+        (options-list (when options (append options nil)))) ; Convert vector to list
+    (cond
+     ;; Parent buffer exists but is dead
+     ((and parent-buffer (not (buffer-live-p parent-buffer)))
+      (funcall callback "Error: Parent buffer is no longer available."))
+     (t
+      ;; Use parent buffer if available, otherwise use current buffer (top-level agent)
+      (let ((target-buffer (or parent-buffer agent-buffer)))
+        ;; Store pending request in this agent buffer
+        (push (list :id request-id
+                    :callback callback
+                    :question question
+                    :options options-list
+                    :context context
+                    :default default
+                    :timestamp (current-time))
+              gptel-agent--pending-user-requests)
+        ;; Display in target buffer
+        (with-current-buffer target-buffer
+          (gptel-agent--display-user-request 
+           agent-buffer request-id question options-list context default))
+        ;; Don't call callback yet - it will be called when user responds
+        ;; Return nil to indicate we're waiting
+        nil)))))
+
+(defun gptel-agent--display-user-request (agent-buffer request-id question options context default)
+  "Display a user request prompt in the current (parent) buffer.
+AGENT-BUFFER is the sub-agent requesting input.
+REQUEST-ID identifies this specific request.
+QUESTION is the question to display.
+OPTIONS is a list of suggested choices.
+CONTEXT is additional context.
+DEFAULT is the default answer."
+  (let ((inhibit-read-only t)
+        (agent-name (buffer-local-value 'gptel-agent--agent-type agent-buffer))
+        (task-desc (buffer-local-value 'gptel-agent--task-description agent-buffer)))
+    (goto-char (point-max))
+    (unless (bolp) (insert "\n"))
+    (let ((start-pos (point))
+          (inner-from))
+      (insert
+       "(" (propertize "AskUser" 'font-lock-face 'font-lock-keyword-face)
+       " " (propertize (format "\"%s\"" (or agent-name "sub-agent"))
+                       'font-lock-face 'font-lock-escape-face)
+       " " (propertize (format "\"%s\"" (truncate-string-to-width
+                                         (or task-desc "task") 30 nil nil "…"))
+                       'font-lock-face 'font-lock-constant-face)
+       ")\n")
+      (setq inner-from (point))
+      ;; Question
+      (insert (propertize question 'font-lock-face 'font-lock-doc-face) "\n")
+      ;; Context
+      (when context
+        (insert "\n"
+                (propertize "Context: " 'font-lock-face 'font-lock-comment-face)
+                context "\n"))
+      ;; Options
+      (when options
+        (insert "\n"
+                (propertize "Options:\n" 'font-lock-face 'font-lock-comment-face))
+        (cl-loop for opt in options
+                 for i from 1
+                 do (insert (propertize (format "  %d. " i)
+                                        'font-lock-face 'font-lock-constant-face)
+                            opt "\n")))
+      ;; Default
+      (when default
+        (insert "\n"
+                (propertize "Default: " 'font-lock-face 'font-lock-comment-face)
+                (propertize default 'font-lock-face 'font-lock-string-face)
+                "\n"))
+      ;; Keybinding hints ABOVE the input area
+      (insert "\n"
+              (propertize "[ C-c C-c: submit | C-c C-k: cancel ]"
+                          'font-lock-face 'font-lock-comment-face)
+              "\n\n")
+      ;; Response area
+      (insert (propertize "Response: " 'font-lock-face 'font-lock-keyword-face))
+      (let ((response-start (point))
+            (overlay-end-marker (make-marker)))
+        (insert "\n")
+        ;; User types here
+        ;; Set marker at the end to track where overlay should extend
+        (set-marker overlay-end-marker (point))
+        ;; Apply block background to the content area
+        (font-lock-append-text-property
+         inner-from (1- (point)) 'font-lock-face (gptel-agent--block-bg))
+        ;; Store metadata as text property on the region
+        (put-text-property start-pos (point)
+                           'gptel-agent-request
+                           (list :agent-buffer agent-buffer
+                                 :request-id request-id
+                                 :response-start response-start
+                                 :default default))
+        ;; Create overlay for the input area with special keymap
+        ;; Use marker for end position so overlay extends as user types
+        (let ((ov (make-overlay start-pos overlay-end-marker)))
+          (overlay-put ov 'gptel-agent-request-overlay t)
+          (overlay-put ov 'gptel-agent-buffer agent-buffer)
+          (overlay-put ov 'gptel-request-id request-id)
+          (overlay-put ov 'keymap
+                       (let ((map (make-sparse-keymap)))
+                         (define-key map (kbd "C-c C-c") #'gptel-agent--submit-user-response)
+                         (define-key map (kbd "C-c C-k") #'gptel-agent--cancel-user-response)
+                         map)))
+        ;; Position cursor for input
+        (goto-char response-start)))))
+
+(defun gptel-agent--find-request-at-point ()
+  "Find the AskUser request overlay at or near point.
+Returns the overlay, or nil if not found."
+  (or (cl-find-if (lambda (ov) (overlay-get ov 'gptel-agent-request-overlay))
+                  (overlays-at (point)))
+      (cl-find-if (lambda (ov) (overlay-get ov 'gptel-agent-request-overlay))
+                  (overlays-in (line-beginning-position) (line-end-position)))
+      ;; Search backwards for request overlay
+      (save-excursion
+        (let ((found nil))
+          (while (and (not found) (not (bobp)))
+            (forward-line -1)
+            (setq found (cl-find-if (lambda (ov) (overlay-get ov 'gptel-agent-request-overlay))
+                                    (overlays-at (point)))))
+          found))))
+
+(defun gptel-agent--submit-user-response ()
+  "Submit the user's response to the requesting sub-agent."
+  (interactive)
+  (let* ((ov (gptel-agent--find-request-at-point)))
+    (unless ov
+      (user-error "Not in an agent request area"))
+    (let* ((agent-buffer (overlay-get ov 'gptel-agent-buffer))
+           (request-id (overlay-get ov 'gptel-request-id))
+           (props (get-text-property (overlay-start ov) 'gptel-agent-request))
+           (response-start (plist-get props :response-start))
+           (default (plist-get props :default)))
+      ;; Extract response text (from response-start to end of overlay)
+      (let ((response (string-trim
+                       (buffer-substring-no-properties
+                        response-start
+                        (overlay-end ov)))))
+        ;; Use default if response is empty
+        (when (string-empty-p response)
+          (setq response (or default "")))
+        ;; Clean up the request display
+        (let ((inhibit-read-only t))
+          (delete-region (overlay-start ov) (overlay-end ov)))
+        (delete-overlay ov)
+        ;; Insert confirmation
+        (insert (propertize (format "[Sent: %s]\n"
+                                    (truncate-string-to-width response 50 nil nil "…"))
+                            'face 'font-lock-comment-face))
+        ;; Deliver response to sub-agent
+        (gptel-agent--deliver-user-response agent-buffer request-id response)))))
+
+(defun gptel-agent--cancel-user-response ()
+  "Cancel the user request without sending a response."
+  (interactive)
+  (let* ((ov (gptel-agent--find-request-at-point)))
+    (unless ov
+      (user-error "Not in an agent request area"))
+    (let* ((agent-buffer (overlay-get ov 'gptel-agent-buffer))
+           (request-id (overlay-get ov 'gptel-request-id)))
+      ;; Clean up the request display
+      (let ((inhibit-read-only t))
+        (delete-region (overlay-start ov) (overlay-end ov)))
+      (delete-overlay ov)
+      ;; Insert cancellation notice
+      (insert (propertize "[Cancelled]\n" 'face 'font-lock-warning-face))
+      ;; Deliver cancellation to sub-agent
+      (gptel-agent--deliver-user-response 
+       agent-buffer request-id 
+       "[User cancelled the request without providing input]"))))
+
+(defun gptel-agent--deliver-user-response (agent-buffer request-id response)
+  "Deliver user RESPONSE to AGENT-BUFFER for REQUEST-ID."
+  (if (not (buffer-live-p agent-buffer))
+      (message "Warning: Sub-agent buffer no longer exists")
+    (with-current-buffer agent-buffer
+      (let ((request (cl-find request-id gptel-agent--pending-user-requests
+                              :key (lambda (r) (plist-get r :id))
+                              :test #'equal)))
+        (if (not request)
+            (message "Warning: Request %s not found in sub-agent" request-id)
+          ;; Remove from pending list
+          (setq gptel-agent--pending-user-requests
+                (cl-remove request gptel-agent--pending-user-requests))
+          ;; Call the callback with the user's response
+          (funcall (plist-get request :callback) response))))))
+
+;;; Tool confirmation via AskUser for sub-agents
+
+(defun gptel-agent--format-tool-call-for-confirmation (tool-spec arg-values)
+  "Format a tool call for user confirmation display.
+TOOL-SPEC is the gptel-tool struct.
+ARG-VALUES is a list of argument values."
+  (let ((name (gptel-tool-name tool-spec))
+        (args (gptel-tool-args tool-spec)))
+    (concat
+     (propertize (format "Tool: %s\n" name) 'face 'font-lock-keyword-face)
+     (propertize (format "Description: %s\n" 
+                         (truncate-string-to-width 
+                          (gptel-tool-description tool-spec) 80 nil nil "…"))
+                 'face 'font-lock-doc-face)
+     (propertize "Arguments:\n" 'face 'bold)
+     (cl-loop for arg in args
+              for val in arg-values
+              concat (format "  %s: %s\n"
+                             (propertize (plist-get arg :name) 'face 'font-lock-variable-name-face)
+                             (propertize (truncate-string-to-width 
+                                          (gptel--to-string val) 100 nil nil "…")
+                                         'face 'font-lock-string-face))))))
+
+(defun gptel-agent--confirm-tool-via-askuser (tool-spec arg-values callback)
+  "Request user confirmation for a tool call via AskUser.
+TOOL-SPEC is the gptel-tool struct.
+ARG-VALUES is a list of argument values.
+CALLBACK is called with the user's decision: \"yes\", \"no\", or \"yes-all\"."
+  (let* ((tool-name (gptel-tool-name tool-spec))
+         (context (gptel-agent--format-tool-call-for-confirmation tool-spec arg-values))
+         (question (format "The sub-agent wants to run tool: %s\n\nDo you want to allow this?"
+                           tool-name))
+         (options ["Yes" "No" "Yes to all (auto-approve remaining tools)"]))
+    (gptel-agent--ask-user
+     (lambda (response)
+       (let ((answer (downcase (string-trim response))))
+         (cond
+          ((or (string= answer "yes") (string= answer "1") (string= answer "y"))
+           (funcall callback "yes"))
+          ((or (string-match-p "yes to all\\|3\\|all\\|!" answer))
+           (funcall callback "yes-all"))
+          (t
+           (funcall callback "no")))))
+     question options context "Yes")))
+
+(defun gptel-agent--handle-tool-use-with-confirmation (fsm)
+  "Handle tool use in sub-agent context, using AskUser for confirmation.
+FSM is the gptel state machine.
+This replaces `gptel--handle-tool-use' for sub-agent buffers when tools
+require confirmation."
+  (when-let* ((info (gptel-fsm-info fsm))
+              (backend (plist-get info :backend))
+              ;; Only act on remaining tool calls without results
+              (tool-use (cl-remove-if (lambda (tc) (plist-get tc :result))
+                                      (plist-get info :tool-use)))
+              (ntools (length tool-use))
+              (tool-idx 0))
+    (with-current-buffer (plist-get info :buffer)
+      (let ((result-alist) (pending-confirms))
+        (mapc
+         (lambda (tool-call)
+           (let* ((args (plist-get tool-call :args))
+                  (name (plist-get tool-call :name))
+                  (arg-values nil)
+                  (tool-spec
+                   (cl-find-if
+                    (lambda (ts) (equal (gptel-tool-name ts) name))
+                    (plist-get info :tools)))
+                  (process-tool-result
+                   (lambda (result)
+                     (plist-put info :tool-success t)
+                     (let ((result (gptel--to-string result)))
+                       (plist-put tool-call :result result)
+                       (push (list tool-spec args result) result-alist))
+                     (cl-incf tool-idx)
+                     (when (>= tool-idx ntools)
+                       (gptel--inject-prompt
+                        backend (plist-get info :data)
+                        (gptel--parse-tool-results
+                         backend (plist-get info :tool-use)))
+                       (funcall (plist-get info :callback)
+                                (cons 'tool-result result-alist) info)
+                       (gptel--fsm-transition fsm)))))
+             (if (null tool-spec)
+                 (if (equal name gptel--ersatz-json-tool)
+                     (funcall (plist-get info :callback)
+                              (gptel--json-encode (plist-get tool-call :args))
+                              info)
+                   (message "Unknown tool called by model: %s" name))
+               (setq arg-values
+                     (mapcar
+                      (lambda (arg)
+                        (let ((key (intern (concat ":" (plist-get arg :name)))))
+                          (plist-get args key)))
+                      (gptel-tool-args tool-spec)))
+               ;; Check if we're in a sub-agent and tool requires confirmation
+               (let ((needs-confirm
+                      (and gptel-agent--parent-buffer
+                           gptel-confirm-tool-calls
+                           (not gptel-agent--auto-confirm-tools)
+                           (or (eq gptel-confirm-tool-calls t)
+                               (and-let* ((confirm (gptel-tool-confirm tool-spec)))
+                                 (or (not (functionp confirm))
+                                     (apply confirm arg-values)))))))
+                 (if needs-confirm
+                     ;; Use AskUser for confirmation in sub-agent
+                     (push (list tool-spec arg-values process-tool-result tool-call)
+                           pending-confirms)
+                   ;; Run tool directly
+                   (if (gptel-tool-async tool-spec)
+                       (apply (gptel-tool-function tool-spec)
+                              process-tool-result arg-values)
+                     (let ((result
+                            (condition-case errdata
+                                (apply (gptel-tool-function tool-spec) arg-values)
+                              (error (mapconcat #'gptel--to-string errdata " ")))))
+                       (funcall process-tool-result result))))))))
+         tool-use)
+        ;; Process pending confirmations one at a time
+        (when pending-confirms
+          (gptel-agent--process-pending-confirmations 
+           (nreverse pending-confirms) fsm info))))))
+
+(defun gptel-agent--process-pending-confirmations (pending-list fsm info)
+  "Process PENDING-LIST of tool calls requiring confirmation.
+FSM is the state machine, INFO is the request info."
+  (if (null pending-list)
+      ;; All confirmations processed, check if we need to transition
+      (when (plist-get info :tool-success)
+        (gptel--fsm-transition fsm))
+    (pcase-let ((`(,tool-spec ,arg-values ,process-result ,tool-call) (car pending-list)))
+      (gptel-agent--confirm-tool-via-askuser
+       tool-spec arg-values
+       (lambda (decision)
+         (pcase decision
+           ("yes"
+            ;; Run the tool
+            (if (gptel-tool-async tool-spec)
+                (apply (gptel-tool-function tool-spec)
+                       (lambda (result)
+                         (funcall process-result result)
+                         (gptel-agent--process-pending-confirmations
+                          (cdr pending-list) fsm info))
+                       arg-values)
+              (let ((result
+                     (condition-case errdata
+                         (apply (gptel-tool-function tool-spec) arg-values)
+                       (error (mapconcat #'gptel--to-string errdata " ")))))
+                (funcall process-result result)
+                (gptel-agent--process-pending-confirmations
+                 (cdr pending-list) fsm info))))
+           ("yes-all"
+            ;; Enable auto-confirm for remaining tools
+            (setq gptel-agent--auto-confirm-tools t)
+            ;; Run the tool
+            (if (gptel-tool-async tool-spec)
+                (apply (gptel-tool-function tool-spec)
+                       (lambda (result)
+                         (funcall process-result result)
+                         (gptel-agent--process-pending-confirmations
+                          (cdr pending-list) fsm info))
+                       arg-values)
+              (let ((result
+                     (condition-case errdata
+                         (apply (gptel-tool-function tool-spec) arg-values)
+                       (error (mapconcat #'gptel--to-string errdata " ")))))
+                (funcall process-result result)
+                (gptel-agent--process-pending-confirmations
+                 (cdr pending-list) fsm info))))
+           ("no"
+            ;; Reject the tool call
+            (plist-put tool-call :result "[Tool call rejected by user]")
+            (plist-put info :tool-success t)
+            (gptel-agent--process-pending-confirmations
+             (cdr pending-list) fsm info))))))))
 
 ;;; Tool use preview
 (defun gptel-agent--confirm-overlay (from to &optional no-hide)
@@ -1222,156 +1680,6 @@ the known skills as string ready to be included to the context."
                 (buffer-string)))
           (format "Could not load body of skill %s" skill))))))
 
-;;; Task tool (sub-agent)
-(defvar gptel-agent-request--handlers
-  `((WAIT ,#'gptel-agent--indicate-wait
-          ,#'gptel--handle-wait)
-    (TOOL ,#'gptel-agent--indicate-tool-call
-          ,#'gptel--handle-tool-use))
-  "See `gptel-request--handlers'.")
-
-(defun gptel-agent--task-preview-setup (arg-values _info)
-  "Preview setup for Agent.
-INFO is the tool call info plist.
-ARG-VALUES is a list: (type description prompt)"
-  (pcase-let ((from (point))
-              (`(,type ,desc ,prompt) arg-values))
-    (insert "("
-            (propertize "Agent " 'font-lock-face 'font-lock-keyword-face)
-            (propertize (prin1-to-string type)
-                        'font-lock-face 'font-lock-escape-face)
-            " " (propertize (prin1-to-string desc)
-                            'font-lock-face
-                            '(:inherit font-lock-constant-face :inherit bold))
-            "\n" (propertize (prin1-to-string prompt)
-                             'line-prefix "  "
-                             'wrap-prefix "  "
-                             'font-lock-face 'font-lock-constant-face)
-            ")\n\n")
-    (gptel-agent--confirm-overlay from (point) t)))
-
-(defun gptel-agent--indicate-wait (fsm)
-  "Display waiting indicator for agent task FSM."
-  (when-let* ((info (gptel-fsm-info fsm))
-              (info-ov (plist-get info :context))
-              (count (overlay-get info-ov 'count)))
-    (run-at-time
-     1.5 nil
-     (lambda (ov count)
-       (when (and (overlay-buffer ov)
-                  (eql (overlay-get ov 'count) count))
-         (let* ((task-msg (overlay-get ov 'msg))
-                (new-info-msg
-                 (concat task-msg
-                         (concat
-                          (propertize "Waiting... " 'face 'warning) "\n"
-                          (propertize "\n" 'face
-                                      '(:inherit shadow :underline t :extend t))))))
-           (overlay-put ov 'after-string new-info-msg))))
-     info-ov count)))
-
-(defun gptel-agent--indicate-tool-call (fsm)
-  "Display tool call indicator for agent task FSM."
-  (when-let* ((info (gptel-fsm-info fsm))
-              (tool-use (plist-get info :tool-use))
-              (ov (plist-get info :context)))
-    ;; Update overlay with tool calls
-    (when (overlay-buffer ov)
-      (let* ((task-msg (overlay-get ov 'msg))
-             (info-count (overlay-get ov 'count))
-             (new-info-msg))
-        (setq new-info-msg
-              (concat task-msg
-                      (concat
-                       (propertize "Calling Tools... " 'face 'mode-line-emphasis)
-                       (if (= info-count 0) "\n" (format "(+%d)\n" info-count))
-                       (mapconcat (lambda (call)
-                                    (gptel--format-tool-call
-                                     (plist-get call :name)
-                                     (map-values (plist-get call :args))))
-                                  tool-use)
-                       "\n" gptel-agent--hrule)))
-        (overlay-put ov 'count (+ info-count (length tool-use)))
-        (overlay-put ov 'after-string new-info-msg)))))
-
-(defun gptel-agent--task-overlay (where &optional agent-type description)
-  "Create overlay for agent task at WHERE with AGENT-TYPE and DESCRIPTION."
-  (let* ((bounds                  ;where to place the overlay, handle edge cases
-          (save-excursion
-            (goto-char where)
-            (when (bobp) (insert "\n"))
-            (if (and (bolp) (eolp))
-                (cons (1- (point)) (point))
-              (cons (line-beginning-position) (line-end-position)))))
-         (ov (make-overlay (car bounds) (cdr bounds) nil t))
-         (msg (concat
-               (unless (eq (char-after (car bounds)) 10) "\n")
-               "\n" gptel-agent--hrule
-               (propertize (concat (capitalize agent-type) " Task: ")
-                           'face 'font-lock-escape-face)
-               (propertize description 'face 'font-lock-doc-face) "\n")))
-    (prog1 ov
-      (overlay-put ov 'gptel-agent t)
-      (overlay-put ov 'count 0)
-      (overlay-put ov 'msg msg)
-      (overlay-put ov 'line-prefix "")
-      (overlay-put
-       ov 'after-string
-       (concat msg (propertize "Waiting..." 'face 'warning) "\n"
-               gptel-agent--hrule)))))
-
-(defun gptel-agent--task (main-cb agent-type description prompt)
-  "Call a gptel agent to do specific compound tasks.
-
-MAIN-CB is the main callback to return a value to the main loop.
-AGENT-TYPE is the name of the agent.
-DESCRIPTION is a short description of the task.
-PROMPT is the detailed prompt instructing the agent on what is required."
-  (gptel-with-preset
-      (nconc (list :include-reasoning nil
-                   :use-tools t
-                   :use-context nil)
-             (cdr (assoc agent-type gptel-agent--agents)))
-    (let* ((info (gptel-fsm-info gptel--fsm-last))
-           (where (or (plist-get info :tracking-marker)
-                      (plist-get info :position)))
-           (partial (format "%s result for task: %s\n\n"
-                            (capitalize agent-type) description)))
-      (gptel--update-status " Calling Agent..." 'font-lock-escape-face)
-      (gptel-request prompt
-        :context (gptel-agent--task-overlay where agent-type description)
-        :fsm (gptel-make-fsm :handlers gptel-agent-request--handlers)
-        :callback
-        (lambda (resp info)
-          (let ((ov (plist-get info :context)))
-            (pcase resp
-              ('nil
-               (delete-overlay ov)
-               (funcall main-cb
-                        (format "Error: Task %s could not finish task \"%s\". \
-
-Error details: %S"
-                                agent-type description (plist-get info :error))))
-              (`(tool-call . ,calls)
-               (unless (plist-get info :tracking-marker)
-                 (plist-put info :tracking-marker where))
-               (gptel--display-tool-calls calls info))
-              ((pred stringp)
-               (setq partial (concat partial resp))
-               ;; If tool use is pending, the agent isn't done, so we just
-               ;; accumulate output without printing it.  We print at the end.
-               (unless (plist-get info :tool-use)
-                 (delete-overlay ov)
-                 (when-let* ((transformer (plist-get info :transformer)))
-                   (setq partial (funcall transformer partial)))
-                 (funcall main-cb partial)))
-              ('abort
-               (delete-overlay ov)
-               (funcall main-cb
-                        (format "Error: Task \"%s\" was aborted by the user. \
-%s could not finish."
-                                description agent-type))))))))))
-
 ;;; Register tool call preview functions
 
 (pcase-dolist (`(,tool-name . ,setup-fn)
@@ -1780,7 +2088,7 @@ How to use:
 (gptel-make-tool
  :name "Agent"
  :description "Launch a specialized agent to handle complex, multi-step tasks autonomously.  \
-Agents run independently and return results in one message.  \
+Agents run independently in their own buffer and MUST call AgentFinish when done.  \
 Use for open-ended searches, complex research, or when uncertain about finding results in first few tries."
  :function #'gptel-agent--task
  :args '(( :name "subagent_type"
@@ -1798,6 +2106,70 @@ Should include exactly what information the agent should return."))
  :async t
  :confirm t
  :include t)
+
+;;; Sub-agent control tools (AgentFinish, AskUser)
+
+(gptel-make-tool
+ :name "AgentFinish"
+ :description "Signal that you have completed your task and return results to the delegating agent.
+
+CRITICAL: You MUST call this tool when your task is complete.
+Without calling AgentFinish, your results will NOT be delivered to the delegating agent.
+
+Use status 'success' when the task was completed successfully.
+Use status 'error' when the task could not be completed due to an error.
+Use status 'partial' when you gathered some results but couldn't fully complete the task."
+ :function #'gptel-agent--finish
+ :args '((:name "status"
+          :type string
+          :enum ["success" "error" "partial"]
+          :description "The completion status of the task")
+         (:name "result"
+          :type string
+          :description "The result or findings to return to the delegating agent. \
+For errors, include what went wrong and any partial results.")
+         (:name "summary"
+          :type string
+          :optional t
+          :description "Optional brief one-line summary of the result"))
+ :category "gptel-agent"
+ :include t)
+
+(gptel-make-tool
+ :name "AskUser"
+ :description "Request input or clarification from the user.
+
+Use this when you need user input to proceed with your task.
+The user will be prompted in the main conversation buffer and your execution will pause until they respond.
+
+Examples of when to use:
+- Need clarification on ambiguous requirements
+- Need to choose between multiple valid approaches  
+- Need confirmation before a potentially risky action
+- Need additional information not available in context
+
+Note: Only use this when truly necessary. Try to make reasonable assumptions first."
+ :function #'gptel-agent--ask-user
+ :args '((:name "question"
+          :type string
+          :description "The question or prompt to show the user")
+         (:name "options"
+          :type array
+          :items (:type string)
+          :optional t
+          :description "Optional list of suggested options/choices for the user")
+         (:name "context"
+          :type string
+          :optional t
+          :description "Additional context to help the user understand the question")
+         (:name "default"
+          :type string
+          :optional t
+          :description "Suggested default answer if user just presses enter"))
+ :category "gptel-agent"
+ :include t
+ :async t
+ :confirm nil)
 
 (provide 'gptel-agent-tools)
 ;;; gptel-agent-tools.el ends here

--- a/gptel-agent.el
+++ b/gptel-agent.el
@@ -74,6 +74,9 @@
 (declare-function project-root "project")
 (declare-function org-get-property-block "org")
 (declare-function org-entry-properties "org")
+(declare-function gptel-agent--confirm-overlay "gptel-agent-tools")
+(declare-function gptel-agent--handle-tool-use-with-confirmation "gptel-agent-tools")
+(declare-function gptel-curl--stream-insert-response "gptel-curl")
 (defvar org-inhibit-startup)
 (defvar project-prompter)
 
@@ -125,6 +128,505 @@ Alist mapping agent names to a plist of agent properties.")
 The key is the name.  The value is a cons (LOCATION . SKILL-PLIST).
 LOCATION is path to the skill's directory.  SKILL-PLIST is the header
 of the corresponding SKILL.md as a plist.")
+
+;;; Sub-agent state tracking variables
+
+(defvar gptel-agent-kill-finished-buffers nil
+  "If non-nil, kill sub-agent buffers when they finish.
+When nil (the default), sub-agent buffers are kept for debugging and inspection.")
+
+;; Parent buffer variables (track active sub-agents)
+(defvar-local gptel-agent--active-subagents nil
+  "List of active sub-agent buffers spawned from this buffer.
+Each entry is a plist with :buffer, :type, :description, :status.")
+
+(defvar-local gptel-agent--user-request-queue nil
+  "Queue of pending user requests from sub-agents.
+Each entry is a plist with :agent-buffer, :request-id, :callback, etc.")
+
+;; Sub-agent buffer variables (store parent context)
+(defvar-local gptel-agent--parent-buffer nil
+  "Reference to the parent buffer that spawned this sub-agent.")
+
+(defvar-local gptel-agent--parent-callback nil
+  "Callback to invoke when this sub-agent finishes (via AgentFinish).")
+
+(defvar-local gptel-agent--agent-type nil
+  "The type of this sub-agent (e.g., \"researcher\", \"executor\").")
+
+(defvar-local gptel-agent--task-description nil
+  "Short description of the task this sub-agent is performing.")
+
+(defvar-local gptel-agent--pending-user-requests nil
+  "List of pending AskUser requests in this sub-agent buffer.
+Each entry is a plist: (:id ID :callback CB :question Q :timestamp TS).")
+
+(defvar-local gptel-agent--auto-confirm-tools nil
+  "When non-nil, automatically approve all tool calls in this sub-agent.
+Set to t when user selects \"Yes to all\" during tool confirmation.")
+
+(defvar gptel-agent--request-id-counter 0
+  "Counter for generating unique request IDs.")
+
+(defvar-local gptel-agent--parent-overlay nil
+  "Overlay in parent buffer showing this sub-agent's task status.
+Used to update parent buffer with tool call progress.")
+
+(defun gptel-agent--generate-request-id ()
+  "Generate a unique request ID for AskUser requests."
+  (format "req-%d-%s"
+          (cl-incf gptel-agent--request-id-counter)
+          (format-time-string "%H%M%S")))
+
+;;; Sub-agent buffer management
+
+(defun gptel-agent--setup-header-line (&optional agent-preset)
+  "Set up the agent header line with preset display.
+AGENT-PRESET is the initial agent type symbol to display (e.g., 'researcher, 'spec-workflow).
+The header line dynamically reads from `gptel--preset' to reflect changes made via gptel-menu."
+  (when gptel-use-header-line
+    ;; Set gptel--preset if an initial preset is provided
+    (when agent-preset
+      (setq-local gptel--preset agent-preset))
+    (setcar header-line-format
+            `(:eval (concat
+                     (propertize " " 'display '(space :align-to 0))
+                     (format "%s" (gptel-backend-name gptel-backend))
+                     (propertize 
+                      (buttonize
+                       (format "[%s]" 
+                               (capitalize 
+                                (replace-regexp-in-string 
+                                 "-" " " 
+                                 (symbol-name (or gptel--preset 'gptel-agent)))))
+                       (lambda (_button) 
+                         (require 'gptel-transient)
+                         (call-interactively #'gptel--preset))
+                       nil
+                       "Choose gptel preset")
+                      'face 'font-lock-keyword-face))))))
+
+(defun gptel-agent--update-subagent-status (status &optional face)
+  "Update the status indicator in a sub-agent buffer's header-line.
+STATUS is the status text to display (e.g., \" Ready\", \" Working...\").
+FACE is the optional face to use (defaults based on STATUS)."
+  (when gptel-use-header-line
+    (let ((status-text (if (stringp status) status (format " %s" status)))
+          (status-face (or face
+                          (pcase status
+                            ((or " Ready" 'ready) 'success)
+                            ((or " Working..." 'working) 'mode-line-emphasis)
+                            ((or " Waiting..." 'waiting) 'warning)
+                            ((or " Error" 'error) 'error)
+                            (_ 'default)))))
+      (when (consp header-line-format)
+        (setf (nth 1 header-line-format)
+              (propertize status-text 'face status-face))
+        (force-mode-line-update)))))
+
+(defun gptel-agent--create-subagent-buffer (agent-type description parent-buffer agent-preset)
+  "Create a dedicated buffer for a sub-agent session.
+AGENT-TYPE is the type of agent (e.g., \"researcher\").
+DESCRIPTION is a short task description.
+PARENT-BUFFER is the buffer that spawned this sub-agent.
+AGENT-PRESET is the preset plist to apply to the buffer.
+Returns the new buffer."
+  (let* ((buf-name (format "*gptel-agent:%s:%s*"
+                           agent-type
+                           (truncate-string-to-width description 30 nil nil "…")))
+         (buf (generate-new-buffer buf-name)))
+    (with-current-buffer buf
+      ;; Inherit major mode from parent buffer (major mode change kills buffer-local variables)
+      (funcall (buffer-local-value 'major-mode parent-buffer))
+      ;; Store parent context AFTER major mode is set
+      (setq-local gptel-agent--parent-buffer parent-buffer)
+      (setq-local gptel-agent--parent-callback nil) ; set later by gptel-agent--task
+      (setq-local gptel-agent--agent-type agent-type)
+      (setq-local gptel-agent--task-description description)
+      (setq-local gptel-agent--pending-user-requests nil)
+      (setq-local gptel-agent--auto-confirm-tools nil)
+      ;; Copy relevant settings from parent
+      (setq-local default-directory (buffer-local-value 'default-directory parent-buffer))
+      (setq-local gptel-backend (buffer-local-value 'gptel-backend parent-buffer))
+      ;; Only copy model/temperature if agent preset didn't specify them
+      (unless (plist-member agent-preset :model)
+        (setq-local gptel-model (buffer-local-value 'gptel-model parent-buffer)))
+      (unless (plist-member agent-preset :temperature)
+        (setq-local gptel-temperature (buffer-local-value 'gptel-temperature parent-buffer)))
+      (setq-local gptel-max-tokens (buffer-local-value 'gptel-max-tokens parent-buffer))
+      (setq-local gptel-stream (buffer-local-value 'gptel-stream parent-buffer))
+      (setq-local gptel-use-curl (buffer-local-value 'gptel-use-curl parent-buffer))
+      ;; Enable gptel-mode for proper conversation tracking
+      (gptel-mode 1)
+      ;; Apply the agent preset AFTER enabling gptel-mode
+      (when agent-preset
+        (gptel--apply-preset
+         (append
+          ;; Agent preset takes priority (may include :include-reasoning)
+          agent-preset
+          ;; Defaults for keys not in preset
+          (list :use-tools t
+                :use-context nil)
+          ;; Inherit reasoning from parent if not specified in preset
+          (unless (plist-member agent-preset :include-reasoning)
+            (list :include-reasoning
+                  (buffer-local-value 'gptel-include-reasoning parent-buffer))))
+         (lambda (sym val) (set (make-local-variable sym) val))))
+      ;; Set up header line to show agent type
+      (gptel-agent--setup-header-line (intern agent-type)))
+    buf))
+
+(defun gptel-agent--register-subagent (parent-buffer agent-buffer type description)
+  "Register a new sub-agent AGENT-BUFFER in PARENT-BUFFER's tracking list.
+TYPE is the agent type, DESCRIPTION is the task description."
+  (with-current-buffer parent-buffer
+    (push (list :buffer agent-buffer
+                :type type
+                :description description
+                :status 'running
+                :start-time (current-time))
+          gptel-agent--active-subagents)))
+
+(defun gptel-agent--unregister-subagent (parent-buffer agent-buffer)
+  "Remove AGENT-BUFFER from PARENT-BUFFER's tracking list."
+  (when (buffer-live-p parent-buffer)
+    (with-current-buffer parent-buffer
+      (setq gptel-agent--active-subagents
+            (cl-remove agent-buffer gptel-agent--active-subagents
+                       :key (lambda (s) (plist-get s :buffer)))))))
+
+(defun gptel-agent--cleanup-subagent (agent-buffer &optional status)
+  "Clean up AGENT-BUFFER after it finishes.
+STATUS is the completion status (for updating parent's tracking)."
+  (when (buffer-live-p agent-buffer)
+    (with-current-buffer agent-buffer
+      ;; Update status indicator
+      (pcase status
+        ('success (gptel-agent--update-subagent-status " Ready" 'success))
+        ('error   (gptel-agent--update-subagent-status " Error" 'error))
+        ('aborted (gptel-agent--update-subagent-status " Aborted" 'error))
+        (_        (gptel-agent--update-subagent-status " Done" 'success)))
+      
+      (when-let* ((parent-buffer gptel-agent--parent-buffer))
+        ;; Update status in parent's tracking
+        (when (buffer-live-p parent-buffer)
+          (with-current-buffer parent-buffer
+            (when-let* ((entry (cl-find agent-buffer gptel-agent--active-subagents
+                                        :key (lambda (s) (plist-get s :buffer)))))
+              (plist-put entry :status (or status 'finished)))))
+        ;; Unregister from parent
+        (gptel-agent--unregister-subagent parent-buffer agent-buffer))
+      ;; Optionally kill the buffer
+      (when gptel-agent-kill-finished-buffers
+        (kill-buffer agent-buffer)))))
+
+;;; Sub-agent FSM handlers
+
+(defun gptel-agent--handle-subagent-done (fsm)
+  "Handle successful completion of sub-agent request FSM.
+
+Sets `gptel--fsm-last' for inspection, runs :post cleanup, and
+auto-notifies the parent if AgentFinish was never called."
+  (let ((info (gptel-fsm-info fsm)))
+    ;; Set fsm-last in the sub-agent buffer for inspection/diagnostics
+    (when-let* ((buf (plist-get info :buffer))
+                ((buffer-live-p buf)))
+      (with-current-buffer buf
+        (setq gptel--fsm-last fsm)))
+    ;; Run :post cleanup callbacks
+    (gptel--handle-post fsm)
+    ;; If AgentFinish was never called, notify the parent so it doesn't hang
+    (when-let* ((buf (plist-get info :buffer))
+                ((buffer-live-p buf)))
+      (with-current-buffer buf
+        (when gptel-agent--parent-callback
+          ;; AgentFinish was NOT called — extract buffer text as fallback result
+          (let* ((result (buffer-substring-no-properties (point-min) (point-max)))
+                 (truncated (truncate-string-to-width result 4000 nil nil t))
+                 (parent-cb gptel-agent--parent-callback)
+                 (parent-buf gptel-agent--parent-buffer)
+                 (agent-type gptel-agent--agent-type)
+                 (description gptel-agent--task-description))
+            (setq gptel-agent--parent-callback nil)
+            (when (buffer-live-p parent-buf)
+              (with-current-buffer parent-buf
+                ;; Delete the task overlay in parent buffer
+                (dolist (ov (overlays-in (point-min) (point-max)))
+                  (when (and (overlay-get ov 'gptel-agent)
+                             (equal (overlay-get ov 'gptel-agent-buffer) buf))
+                    (delete-overlay ov)))
+                ;; Notify parent with partial status (not error - agent did produce output)
+                (funcall parent-cb
+                         (format "%s result for task: %s\n\nStatus: partial\nSummary: Agent completed without calling AgentFinish\n\n%s"
+                                 (capitalize (or agent-type "Agent"))
+                                 (or description "unknown task")
+                                 truncated))))
+            (gptel-agent--cleanup-subagent buf 'finished)))))))
+
+(defun gptel-agent--handle-subagent-error (fsm)
+  "Handle error in sub-agent request FSM.
+
+Captures error from INFO, notifies the parent, and cleans up."
+  (let ((info (gptel-fsm-info fsm)))
+    ;; Set fsm-last for inspection
+    (when-let* ((buf (plist-get info :buffer))
+                ((buffer-live-p buf)))
+      (with-current-buffer buf
+        (setq gptel--fsm-last fsm)))
+    ;; Run :post cleanup
+    (gptel--handle-post fsm)
+    ;; Notify parent of the error
+    (when-let* ((buf (plist-get info :buffer))
+                ((buffer-live-p buf)))
+      (with-current-buffer buf
+        (when gptel-agent--parent-callback
+          (let* ((error-data (plist-get info :error))
+                 (http-msg (plist-get info :status))
+                 (parent-cb gptel-agent--parent-callback)
+                 (parent-buf gptel-agent--parent-buffer)
+                 (agent-type gptel-agent--agent-type)
+                 (description gptel-agent--task-description))
+            (setq gptel-agent--parent-callback nil)
+            (when (buffer-live-p parent-buf)
+              (with-current-buffer parent-buf
+                ;; Delete the task overlay in parent buffer
+                (dolist (ov (overlays-in (point-min) (point-max)))
+                  (when (and (overlay-get ov 'gptel-agent)
+                             (equal (overlay-get ov 'gptel-agent-buffer) buf))
+                    (delete-overlay ov)))
+                ;; Notify parent of error
+                (funcall parent-cb
+                         (format "%s result for task: %s\n\nStatus: error\nHTTP: %s\nError: %S"
+                                 (capitalize (or agent-type "Agent"))
+                                 (or description "unknown task")
+                                 (or http-msg "unknown")
+                                 error-data))))
+            (gptel-agent--cleanup-subagent buf 'error)))))))
+
+(defun gptel-agent--handle-subagent-abort (fsm)
+  "Handle abort of sub-agent request FSM.
+
+Notifies the parent that the sub-agent was aborted."
+  (let ((info (gptel-fsm-info fsm)))
+    ;; Set fsm-last for inspection
+    (when-let* ((buf (plist-get info :buffer))
+                ((buffer-live-p buf)))
+      (with-current-buffer buf
+        (setq gptel--fsm-last fsm)))
+    ;; Notify parent of the abort
+    (when-let* ((buf (plist-get info :buffer))
+                ((buffer-live-p buf)))
+      (with-current-buffer buf
+        (when gptel-agent--parent-callback
+          (let ((parent-cb gptel-agent--parent-callback)
+                (parent-buf gptel-agent--parent-buffer)
+                (description gptel-agent--task-description))
+            (setq gptel-agent--parent-callback nil)
+            (when (buffer-live-p parent-buf)
+              (with-current-buffer parent-buf
+                ;; Delete the task overlay in parent buffer
+                (dolist (ov (overlays-in (point-min) (point-max)))
+                  (when (and (overlay-get ov 'gptel-agent)
+                             (equal (overlay-get ov 'gptel-agent-buffer) buf))
+                    (delete-overlay ov)))
+                ;; Notify parent of abort
+                (funcall parent-cb
+                         (format "Error: Task \"%s\" was aborted."
+                                 (or description "unknown task")))))
+            (gptel-agent--cleanup-subagent buf 'aborted)))))))
+
+;;; Sub-agent task orchestration
+
+(defconst gptel-agent--hrule
+  (propertize "\n" 'face '(:inherit shadow :underline t :extend t)))
+
+(defvar gptel-agent-request--handlers
+  `((WAIT ,#'gptel-agent--indicate-wait
+          ,#'gptel--handle-wait)
+    (TOOL ,#'gptel-agent--indicate-tool-call
+          ,#'gptel-agent--handle-tool-use-with-confirmation)
+    (DONE ,#'gptel-agent--handle-subagent-done)
+    (ERRS ,#'gptel-agent--handle-subagent-error)
+    (ABRT ,#'gptel-agent--handle-subagent-abort))
+  "See `gptel-request--handlers'.
+Uses custom tool handling that routes confirmations through AskUser.")
+
+(defun gptel-agent--task-preview-setup (arg-values _info)
+  "Preview setup for Agent.
+INFO is the tool call info plist.
+ARG-VALUES is a list: (type description prompt)"
+  (pcase-let ((from (point))
+              (`(,type ,desc ,prompt) arg-values))
+    (insert "("
+            (propertize "Agent " 'font-lock-face 'font-lock-keyword-face)
+            (propertize (prin1-to-string type)
+                        'font-lock-face 'font-lock-escape-face)
+            " " (propertize (prin1-to-string desc)
+                            'font-lock-face
+                            '(:inherit font-lock-constant-face :inherit bold))
+            "\n" (propertize (prin1-to-string prompt)
+                             'line-prefix "  "
+                             'wrap-prefix "  "
+                             'font-lock-face 'font-lock-constant-face)
+            ")\n\n")
+    (gptel-agent--confirm-overlay from (point) t)))
+
+(defun gptel-agent--indicate-wait (fsm)
+  "Display waiting indicator for agent task FSM."
+  (when-let* ((info (gptel-fsm-info fsm))
+              (info-ov (plist-get info :context))
+              (count (overlay-get info-ov 'count)))
+    (run-at-time
+     1.5 nil
+     (lambda (ov count)
+       (when (and (overlay-buffer ov)
+                  (eql (overlay-get ov 'count) count))
+         (let* ((task-msg (overlay-get ov 'msg))
+                (new-info-msg
+                 (concat task-msg
+                         (concat
+                          (propertize "Waiting... " 'face 'warning) "\n"
+                          (propertize "\n" 'face
+                                      '(:inherit shadow :underline t :extend t))))))
+           (overlay-put ov 'after-string new-info-msg))))
+     info-ov count)))
+
+(defun gptel-agent--indicate-tool-call (fsm)
+  "Display tool call indicator for agent task FSM."
+  (when-let* ((info (gptel-fsm-info fsm))
+              (tool-use (plist-get info :tool-use)))
+    ;; Update parent buffer overlay if this is a sub-agent
+    (when (and gptel-agent--parent-buffer
+               gptel-agent--parent-overlay
+               (overlay-buffer gptel-agent--parent-overlay))
+      (let* ((task-msg (overlay-get gptel-agent--parent-overlay 'msg))
+             (info-count (overlay-get gptel-agent--parent-overlay 'count))
+             (new-info-msg))
+        (setq new-info-msg
+              (concat task-msg
+                      (concat
+                       (propertize "Calling Tools... " 'face 'mode-line-emphasis)
+                       (if (= info-count 0) "\n" (format "(+%d)\n" info-count))
+                       (mapconcat (lambda (call)
+                                    (gptel--format-tool-call
+                                     (plist-get call :name)
+                                     (map-values (plist-get call :args))))
+                                  tool-use)
+                       "\n" gptel-agent--hrule)))
+        (overlay-put gptel-agent--parent-overlay 'count 
+                     (+ info-count (length tool-use)))
+        (overlay-put gptel-agent--parent-overlay 'after-string new-info-msg)))))
+
+(defun gptel-agent--task-overlay (where &optional agent-type description)
+  "Create overlay for agent task at WHERE with AGENT-TYPE and DESCRIPTION."
+  (let* ((bounds                  ;where to place the overlay, handle edge cases
+          (save-excursion
+            (goto-char where)
+            (when (bobp) (insert "\n"))
+            (if (and (bolp) (eolp))
+                (cons (1- (point)) (point))
+              (cons (line-beginning-position) (line-end-position)))))
+         (ov (make-overlay (car bounds) (cdr bounds) nil t))
+         (msg (concat
+               (unless (eq (char-after (car bounds)) 10) "\n")
+               "\n" gptel-agent--hrule
+               (propertize (concat (capitalize agent-type) " Task: ")
+                           'face 'font-lock-escape-face)
+               (propertize description 'face 'font-lock-doc-face) "\n")))
+    (prog1 ov
+      (overlay-put ov 'gptel-agent t)
+      (overlay-put ov 'count 0)
+      (overlay-put ov 'msg msg)
+      (overlay-put ov 'line-prefix "")
+      (overlay-put
+       ov 'after-string
+       (concat msg (propertize "Waiting..." 'face 'warning) "\n"
+               gptel-agent--hrule)))))
+
+(defun gptel-agent--task (main-cb agent-type description prompt)
+  "Call a gptel agent in a dedicated buffer.
+
+MAIN-CB is the callback to return results to the parent agent.
+AGENT-TYPE is the name of the agent preset (e.g., \"researcher\").
+DESCRIPTION is a short description of the task.
+PROMPT is the detailed prompt instructing the agent on what to do.
+
+The sub-agent runs in its own buffer with its own conversation context.
+It MUST call AgentFinish when done to deliver results back to the parent.
+It MAY call AskUser to request user input during execution."
+  (let* ((parent-buffer (current-buffer))
+         (parent-info (gptel-fsm-info gptel--fsm-last))
+         (where (or (plist-get parent-info :tracking-marker)
+                    (plist-get parent-info :position)))
+         (agent-preset (cdr (assoc agent-type gptel-agent--agents)))
+         (agent-buffer (gptel-agent--create-subagent-buffer
+                        agent-type description parent-buffer agent-preset)))
+
+    ;; Register the sub-agent in parent's tracking
+    (gptel-agent--register-subagent parent-buffer agent-buffer agent-type description)
+
+    ;; Create status overlay in parent buffer
+    (let ((ov (gptel-agent--task-overlay where agent-type description)))
+      ;; Store reference to agent buffer in overlay for cleanup
+      (overlay-put ov 'gptel-agent-buffer agent-buffer)
+      ;; Store parent overlay in sub-agent buffer for tool call updates
+      (with-current-buffer agent-buffer
+        (setq-local gptel-agent--parent-overlay ov)))
+
+    (gptel--update-status " Calling Agent..." 'font-lock-escape-face)
+
+    ;; Set up and run the request in the sub-agent buffer
+    (with-current-buffer agent-buffer
+      ;; Update status to Working
+      (gptel-agent--update-subagent-status " Working..." 'mode-line-emphasis)
+      
+      ;; Store the parent callback - AgentFinish will use this
+      (setq gptel-agent--parent-callback main-cb)
+
+      ;; Insert the initial prompt
+      (insert prompt "\n")
+
+      (gptel-request nil  ; Use buffer contents as prompt
+        :stream t
+        :fsm (gptel-make-fsm :handlers gptel-agent-request--handlers)
+        :callback #'gptel-agent--subagent-callback))))
+
+(defun gptel-agent--subagent-callback (response info)
+  "Callback for sub-agent responses.
+RESPONSE is the LLM response, INFO is the request info plist."
+  (pcase response
+    ('nil
+     ;; Error case — insert into sub-agent buffer for visibility.
+     ;; The ERRS FSM handler will notify the parent.
+     (let ((error-msg (plist-get info :error)))
+       (message "Sub-agent error: %S" error-msg)
+       (when-let* ((buf (plist-get info :buffer))
+                   ((buffer-live-p buf)))
+         (with-current-buffer buf
+           (goto-char (point-max))
+           (insert (propertize (format "\n[Error: %S]\n" error-msg)
+                               'face 'error))))))
+
+    (`(tool-call . ,calls)
+     ;; Tool calls in sub-agent buffers are handled by the FSM
+     ;; The FSM will display them and auto-confirm via gptel-agent--auto-confirm-tools
+     nil)
+
+    ((pred stringp)
+     ;; Insert response in sub-agent buffer
+     (if (plist-get info :stream)
+         (gptel-curl--stream-insert-response response info)
+       (gptel--insert-response response info)))
+
+    ('t
+     ;; Stream finished successfully.
+     ;; The DONE FSM handler will check if AgentFinish was called
+     ;; and notify the parent if not.
+     nil)
+
+    ('abort
+     ;; User aborted — the ABRT FSM handler will notify the parent.
+     nil)))
 
 ;;;###autoload
 (defun gptel-agent-read-file (agent-file &optional templates metadata-only)
@@ -356,7 +858,17 @@ Signals an error if:
                   (pcase key
                     ((or :pre :post) (plist-put parsed-yaml key (eval (read val) t)))
                     (:parents (plist-put parsed-yaml key
-                                         (mapcar #'intern (ensure-list (read val)))))))))
+                                         (mapcar #'intern (ensure-list (read val)))))
+                    ;; Convert model string to symbol (gptel expects a symbol)
+                    (:model (plist-put parsed-yaml key (intern val)))
+                    ;; Convert YAML boolean strings to elisp booleans
+                    ((or :confirm-tool-calls :include-reasoning)
+                     (plist-put parsed-yaml key
+                                (pcase val
+                                  ((or "no" "false" :json-false :false) nil)
+                                  ((or "yes" "true" t :json-true :true) t)
+                                  ("auto" 'auto)
+                                  (_ val))))))))
 
             ;; Validate all keys in the parsed YAML
             (let ((current-plist parsed-yaml))
@@ -440,7 +952,16 @@ Signals an error if:
 
               (pcase key-sym
                 (:context (setq value (split-string value)))
-                (:tools (setq value (split-string value))))
+                (:tools (setq value (split-string value)))
+                ;; Convert model string to symbol (gptel expects a symbol)
+                (:model (setq value (intern value)))
+                ;; Convert boolean strings to elisp booleans
+                ((or :confirm-tool-calls :include-reasoning)
+                 (setq value (pcase value
+                               ((or "no" "false" "nil") nil)
+                               ((or "yes" "true" "t") t)
+                               ("auto" 'auto)
+                               (_ value)))))
 
               ;; Skip CATEGORY property (added automatically by Org)
               (unless (string-equal key-str "category")
@@ -494,37 +1015,18 @@ this session, which defaults to the default `gptel-agent'."
                 (and (use-region-p)
                      (buffer-substring (region-beginning)
                                        (region-end)))
-                'interactive)))
+                'interactive))
+        (preset-to-use (or agent-preset 'gptel-agent)))
     (with-current-buffer gptel-buf
       (setq default-directory project-dir)
       (gptel-agent-update)              ;Update all agent definitions
       (gptel--apply-preset              ;Apply the gptel-agent preset
-       (or agent-preset 'gptel-agent)
+       preset-to-use
        (lambda (sym val) (set (make-local-variable sym) val)))
       (unless gptel-max-tokens          ;Agent tasks typically need
         (setq gptel-max-tokens 8192))   ;a higher than usual value
-      (when gptel-use-header-line
-        (let* ((agent-mode t)
-               (switch-mode
-                (lambda (&rest _)
-                  (gptel--apply-preset
-                   (if agent-mode 'gptel-plan 'gptel-agent)
-                   (lambda (sym val) (set (make-local-variable sym) val)))
-                  (setq agent-mode (not agent-mode))
-                  (force-mode-line-update)))
-               (display-mode
-                (lambda () (concat
-                       (propertize " " 'display '(space :align-to 0))
-                       (format "%s" (gptel-backend-name gptel-backend))
-                       (if agent-mode
-                           (propertize (buttonize "[Agent]" switch-mode nil
-                                                  "Switch to planning preset")
-                                       'face 'font-lock-keyword-face)
-                         (propertize (buttonize "[Plan]" switch-mode nil
-                                                "Switch to agent preset")
-                                     'face 'font-lock-doc-face))))))
-          (setcar header-line-format
-                  `(:eval (funcall ,display-mode))))))))
+      ;; gptel--apply-preset sets gptel--preset, so header line will pick it up
+      (gptel-agent--setup-header-line preset-to-use))))
 
 (provide 'gptel-agent)
 


### PR DESCRIPTION
What:
This change adds support for delegating work to sub-agents that is tracked in an independent buffer (1 per sub-agent).

Why:
I have custom agents that delegate work to multiple specialized sub-agents. Sometimes these sub-agents fail for a number of reasons - tool call failures, token limits, incorrect/missing context. Operating in an indepedent buffers provides us with the ability to resume partially complete work by providing additional instructions/context to the sub-agent.

New tools:
- The `AgentFinish` tool call allows for callbacks to the delegating/parent agent. This is the mechanism with which sub-agents indicate that they have finished their work.
- The `AskUser` tool call allows the user to interact with sub-agents from a single window (the one from the delegating agent). Sub-agents can request user input using this tool, and the request shows up in the delegating agent's buffer.