### PR TITLE
Extract gptel-agent--truncate-large-buffer from gptel-agent--glob

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -924,6 +924,45 @@ PATH, FILENAME, and CONTENT must all be strings."
       (error "Error: Could not write file %s:\n%S" path errdata))))
 
 ;;;; Find files using regexes
+(defun gptel-agent--truncate-buffer (prefix &optional max-lines)
+  "Truncate the current buffer if it exceeds 20000 chars.
+
+Save the full content to a temporary file and replace the buffer
+with a truncated preview when the size limit is exceeded.
+
+PREFIX is a string identifier for the temporary file name.
+MAX-LINES is the number of lines to keep, defaulting to 50."
+  ;; Too large - save to temp file and return truncated info
+  (when (> (buffer-size) 20000)
+    (let* ((max-lines (or max-lines 50))
+           (temp-dir (expand-file-name "gptel-agent-temp"
+                                       (temporary-file-directory)))
+           (temp-file (expand-file-name
+                       (format "%s-%s-%s.txt"
+                               prefix
+                               (format-time-string "%Y%m%d-%H%M%S")
+                               (random 10000))
+                       temp-dir))
+           (orig-size (buffer-size))
+           (orig-lines (line-number-at-pos (point-max))))
+      ;; Create temp directory if needed
+      (unless (file-directory-p temp-dir)
+        (make-directory temp-dir t))
+      ;; Save full content
+      (write-region nil nil temp-file)
+      ;; Insert truncated header
+      (goto-char (point-min))
+      (insert (format "%s results too large (%d chars, %d lines) \
+ for context window.\nStored in: %s\n\nFirst %d lines:\n\n"
+                      prefix orig-size orig-lines temp-file max-lines))
+      ;; Truncate to first max-lines lines
+      (forward-line max-lines)
+      (delete-region (point) (point-max))
+      ;; Add footer with read instruction
+      (goto-char (point-max))
+      (insert (format "\n\n[Use Read tool with file_path=\"%s\" to view full results]"
+                      temp-file)))))
+
 (defun gptel-agent--glob (pattern &optional path depth)
   "Find files matching PATTERN using the `tree' command.
 
@@ -959,32 +998,7 @@ Raises an error if PATTERN is empty, PATH is not readable, or the
           (goto-char (point-min))
           (insert (format "Glob failed with exit code %d\n.STDOUT:\n\n"
                           exit-code))))
-      (when (> (buffer-size) 20000)
-        ;; Too large - save to temp file and return truncated info
-        (let* ((temp-dir (expand-file-name "gptel-agent-temp"
-                                           (temporary-file-directory)))
-               (temp-file (expand-file-name
-                           (format "glob-%s-%s.txt"
-                                   (format-time-string "%Y%m%d-%H%M%S")
-                                   (random 10000))
-                           temp-dir)))
-          (unless (file-directory-p temp-dir) (make-directory temp-dir t))
-          (write-region nil nil temp-file)
-          (let ((max-lines 50)
-                (orig-size (buffer-size))
-                (orig-lines (line-number-at-pos (point-max))))
-            ;; Insert header
-            (goto-char (point-min))
-            (insert (format "Glob results too large (%d chars, %d lines)\
- for context window.\nStored in: %s\n\nFirst %d lines:\n\n"
-                            orig-size orig-lines temp-file max-lines))
-            ;; Truncate to first max-lines lines
-            (forward-line max-lines)
-            (delete-region (point) (point-max))
-            ;; Insert footer
-            (goto-char (point-max))
-            (insert (format "\n\n[Use Read tool with file_path=\"%s\" to view full results]"
-                            temp-file)))))
+      (gptel-agent--truncate-buffer "glob")
       (buffer-string))))
 
 ;;;; Read files or directories


### PR DESCRIPTION
Extract gptel-agent--truncate-large-buffer from gptel-agent--glob, then this function will be applied to other tool as well, such as gptel-agent--grep.
The reason behind this is that, in my case, I'm using deepseek, sometime, it will use grep with filters like "*.cpp" or "*.xxx" which will result a very large result, leads to context windows blown up.
so I'm thinking, maybe we could introduce this gptel-agent--truncate-large-buffer for grep tool as well. (will be a separate commit after both this commit and https://github.com/karthink/gptel-agent/pull/57 merged.)