### PR TITLE
Add "git-grep" support to gptel-agent--grep.

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -1105,14 +1105,37 @@ and optional context.  Results are limited to 1000 or fewer matches per
 file.  Results are sorted by modification time."
   (unless (file-readable-p path)
     (error "Error: File or directory %s is not readable" path))
-  (let ((grepper (or (executable-find "rg") (executable-find "grep"))))
-    (unless grepper
-      (error "Error: ripgrep/grep not available, this tool cannot be used"))
+  (let* ((full-path (expand-file-name (substitute-in-file-name path)))
+         (git-root (and (executable-find "git") (locate-dominating-file full-path ".git")))
+         (grepper (cond
+                   (git-root "git")
+                   ((executable-find "rg") "rg")
+                   ((executable-find "grep") "grep")
+                   (t (error "Error: ripgrep/grep/git-grep not available, \
+this tool cannot be used")))))
     (with-temp-buffer
-      (let* ((cmd (file-name-sans-extension (file-name-nondirectory grepper)))
+      (let* ((default-directory (or git-root default-directory))
              (args
               (cond
-               ((string= "rg" cmd)
+               ((string= "git" grepper)
+                (let* ((rel-path (file-relative-name full-path git-root))
+                       (pathspecs
+                        (list (if (and glob (file-directory-p full-path))
+                                  (file-name-concat rel-path glob)
+                                rel-path))))
+                  (delq nil
+                        (nconc
+                         (list "grep"
+                               "--line-number"
+                               "--no-color"
+                               (and (natnump context-lines)
+                                    (format "-C%d" context-lines))
+                               "--max-count=1000"
+                               "--untracked"
+                               "-P" regex
+                               "--")
+                         pathspecs))))
+               ((string= "rg" grepper)
                 (delq nil (list "--sort=modified"
                                 (and (natnump context-lines)
                                      (format "--context=%d" context-lines))
@@ -1120,20 +1143,20 @@ file.  Results are sorted by modification time."
                                 ;; "--files-with-matches"
                                 "--max-count=1000"
                                 "--heading" "--line-number" "-e" regex
-                                (expand-file-name (substitute-in-file-name path)))))
-               ((string= "grep" cmd)
+                                full-path)))
+               ((string= "grep" grepper)
                 (delq nil (list "--recursive"
                                 (and (natnump context-lines)
                                      (format "--context=%d" context-lines))
                                 (and glob (format "--include=%s" glob))
                                 "--max-count=1000"
                                 "--line-number" "--regexp" regex
-                                (expand-file-name (substitute-in-file-name path)))))
-               (t (error "Error: failed to identify grepper"))))
+                                full-path)))))
              (exit-code (apply #'call-process grepper nil '(t t) nil args)))
         (when (/= exit-code 0)
           (goto-char (point-min))
           (insert (format "Error: search failed with exit-code %d.  Tool output:\n\n" exit-code)))
+        (gptel-agent--truncate-buffer "grep")
         (buffer-string)))))
 
 ;;; Todo-write tool (task tracking)


### PR DESCRIPTION
Add "git-grep" support to gptel-agent--grep.

Now, preference order:

1. git grep (if inside a git repo)
2. ripgrep (rg)
3. grep" reason for this is inside a large repo: the git-grep would normally run faster than rg. and the bigger the repo is, the faster the git-grep will get.