### PR TITLE
Refactor Edit tool to fix gptel-agent--edit-files-preview-setup bug halting tool call.

### DIFF
--- a/agents/executor.md
+++ b/agents/executor.md
@@ -242,15 +242,19 @@ The delegating agent chose you because:
 **When NOT to use `Edit`:**
 - Creating brand new files → use `Write`
 - You haven't read the file yet → must `Read` first (tool will error)
-- The old_string is not unique and you want to replace all occurrences → use `replace_all: true`
 
-**How to use `Edit`:**
+**How to use `Edit` for SINGLE replacement:**
 - MUST `Read` the file first (required, tool will error otherwise)
-- Provide exact `old_string` to match (including proper indentation from file content)
+- Provide exact `old_string` to match (including proper indentation from file content, not line number prefixes)
 - Provide `new_string` as replacement (must be different from old_string)
-- The edit will FAIL if old_string is not unique unless `replace_all: true` is set
-- Preserve exact indentation from the file content
+- The edit will FAIL if old_string is not unique
+- Preserve exact indentation from the file content (ignore line number prefixes from `Read` output)
 - Always prefer editing existing files over creating new ones
+
+**How to use `Edit` for MULTIPLE replacement:**
+- Leave `old_string` nil or as empty string
+- Provide `new_string` as diff within fenced code blocks (=diff or =patch) and be in unified format
+- There must be the file paths within the diff. e.g. ('--- a/filename' '+++ b/filename') are appropriate for the 'path'.
 </tool>
 
 <tool name="Write">

--- a/agents/gptel-agent.md
+++ b/agents/gptel-agent.md
@@ -359,15 +359,19 @@ You MUST create a todo list immediately when:
 **When NOT to use `Edit`:**
 - Creating brand new files → use `Write`
 - You haven't read the file yet → must `Read` first (tool will error)
-- The old_string is not unique and you want to replace all occurrences → use `replace_all: true`
 
-**How to use `Edit`:**
+**How to use `Edit` for SINGLE replacement:**
 - MUST `Read` the file first (required, tool will error otherwise)
 - Provide exact `old_string` to match (including proper indentation from file content, not line number prefixes)
 - Provide `new_string` as replacement (must be different from old_string)
 - The edit will FAIL if old_string is not unique
 - Preserve exact indentation from the file content (ignore line number prefixes from `Read` output)
 - Always prefer editing existing files over creating new ones
+
+**How to use `Edit` for MULTIPLE replacement:**
+- Leave `old_string` nil or as empty string
+- Provide `new_string` as diff within fenced code blocks (=diff or =patch) and be in unified format
+- There must be the file paths within the diff. e.g. ('--- a/filename' '+++ b/filename') are appropriate for the 'path'.
 </tool>
 
 <tool name="Write">

--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -591,9 +591,9 @@ diagnostics."
 (defun gptel-agent--edit-files-preview-setup (arg-values _info)
   "Insert tool call preview for ARG-VALUES for \"Edit\" tool."
   (pcase-let ((from (point)) (files-affected) (description)
-              (`(,path ,old-str ,new-str-or-diff ,diffp) arg-values))
+              (`(,path ,new-str-or-diff ,old-str) arg-values))
 
-    (if (and diffp (not (eq diffp :json-false)))
+    (if (or (not old-str) (string= old-str ""))
         (progn                          ;Patch
           (insert new-str-or-diff)
           (save-excursion
@@ -608,7 +608,7 @@ diagnostics."
           (setq description "Patch")
           (require 'diff-mode)
           (gptel-agent--fontify-block 'diff-mode from (point)))
-      (when old-str                     ;Text replacement
+      (progn                     ;Text replacement
         (push path files-affected)
         (setq description "ReplaceIn")
         (insert

--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -682,29 +682,27 @@ directory to create."
         (format "Directory %s created/verified in %s" name parent))
     (error "Error creating directory %s in %s:\n%S" name parent errdata)))
 
-(defun gptel-agent--edit-files (path &optional old-str new-str-or-diff diffp)
+(defun gptel-agent--edit-files (path new-str-or-diff &optional old-str )
   "Replace text in file(s) at PATH using either string matching or unified diff.
 
 This function supports two distinct modes of operation:
 
-1. STRING REPLACEMENT MODE (DIFFP is nil or :json-false):
+1. STRING REPLACEMENT MODE (OLD-STR is not nil and not \"\"):
    - Searches for OLD-STR in the file at PATH
    - Replaces it with NEW-STR-OR-DIFF
    - Requires OLD-STR to match exactly once (uniquely) in the file
-   - Only works on single files, not directories
+   - Only works on a single file, not directory
 
-2. DIFF/PATCH MODE (when DIFFP is non-nil and not :json-false):
+2. DIFF/PATCH MODE (when OLD-STR is nil or \"\"):
    - Applies NEW-STR-OR-DIFF as a unified diff using the `patch` command
    - Works on both single files and directories
-   - OLD-STR is ignored in this mode
    - NEW-STR-OR-DIFF can contain the diff in fenced code blocks
      (=diff or =patch)
    - Uses the -N (--forward) option to ignore already-applied patches
 
 PATH - File or directory path to modify (must be readable)
-OLD-STR - (String mode only) Exact text to find and replace
 NEW-STR-OR-DIFF - Replacement text (string mode) or unified diff (diff mode)
-DIFFP - If non-nil (and not :json-false), use diff/patch mode
+OLD-STR - If it is nil or \"\", use diff/patch mode, else it is the exact text to find and replace
 
 Error Conditions:
   - PATH not readable
@@ -724,7 +722,7 @@ Signals:
   (unless new-str-or-diff
     (error "Required argument `new_str' missing"))
 
-  (if (or (eq diffp :json-false) old-str)
+  (if (and old-str (not (string= old-str "")))
       ;; Replacement by Text
       (progn
         (when (file-directory-p path)
@@ -1584,13 +1582,13 @@ For the replacement, there are two methods:
 - Short replacements: Provide both `old_str` and `new_str`, in which case `old_str` \
 needs to exactly match one unique section of the original file, including any whitespace.  \
 Make sure to include enough context that the match is not ambiguous.  \
-The entire original string will be replaced with `new str`.
-- Long or involved replacements: set the `diff` parameter to true and provide a unified diff \
-in `new_str`. `old_str` can be ignored.
+The entire original string will be replaced with `new_str`.
+- Long or involved replacements: provide a unified diff in `new_str`. \
+set `old_str` to nil or empty.
 
 To edit multiple files,
 - provide the directory path,
-- set the `diff` parameter to true
+- set the `old_str` parameter nil or empty string
 - and provide a unified diff in `new_str`.
 
 Diff instructions:
@@ -1604,16 +1602,13 @@ To simply insert text at some line, use the \"Insert\" instead."
  :args '(( :name "path"
            :description "File path or directory to edit"
            :type string)
-         ( :name "old_str"
-           :description "Original string to replace.  If providing a unified diff, this should be false"
-           :type string
-           :optional t)
          ( :name "new_str"
            :description "Replacement string OR unified diff text"
            :type string)
-         ( :name "diff"
-           :description "Whether the replacement is a string or a diff.  `true` for a diff, `false` otherwise."
-           :type boolean))
+         ( :name "old_str"
+           :description "If \"Short replacements\", it is original string to replace, else if for \"Diff\", this should be nil or a empty string"
+           :type string
+           :optional t))
  :category "gptel-agent"
  :confirm t
  :include t)

--- a/gptel-agent.el
+++ b/gptel-agent.el
@@ -534,7 +534,8 @@ this session, which defaults to the default `gptel-agent'."
                                                 "Switch to agent preset")
                                      'face 'font-lock-doc-face))))))
           (setcar header-line-format
-                  `(:eval (funcall ,display-mode))))))))
+                  `(:eval (funcall ,display-mode))))))
+    gptel-buf))
 
 (provide 'gptel-agent)
 


### PR DESCRIPTION
Below is a piece of problematic code excrept from gptel-agent:
```
(defun gptel-agent--edit-files-preview-setup (arg-values _info)
  "Insert tool call preview for ARG-VALUES for \"Edit\" tool."
  (pcase-let ((from (point)) (files-affected) (description)
              (`(,path ,old-str ,new-str-or-diff ,diffp) arg-values))

    (if (and diffp (not (eq diffp :json-false)))
        (progn                          ;Patch
          (insert new-str-or-diff)
          (save-excursion
            (while (re-search-backward "^\\+\\+\\+ \\(.*\\)$" from t)
              (push (match-string 1) files-affected))
            (goto-char from)
            (when (looking-at "^ *```\\(diff\\|patch\\)\\s-*\n")
              (delete-region (match-beginning 0) (match-end 0))))
          (skip-chars-backward " \t\r\n")
          (when (looking-back "^ *```\\s-*\\'" (line-beginning-position))
            (delete-region (line-beginning-position) (line-end-position)))
          (setq description "Patch")
          (require 'diff-mode)
          (gptel-agent--fontify-block 'diff-mode from (point)))
      (when old-str                     ;Text replacement
        (push path files-affected)
        (setq description "ReplaceIn")
        (insert
         (propertize old-str 'font-lock-face 'diff-removed
                     'line-prefix (propertize "-" 'face 'diff-removed))
         "\n" (propertize new-str-or-diff 'font-lock-face 'diff-added
                          'line-prefix (propertize "+" 'face 'diff-added))
         "\n")))
    (insert "\n")
    (font-lock-append-text-property
     from (1- (point)) 'font-lock-face (gptel-agent--block-bg))
    (when (derived-mode-p 'org-mode)
      (org-escape-code-in-region from (1- (point))))
    (save-excursion
      (goto-char from)
      (insert
       "(" (propertize description 'font-lock-face 'font-lock-keyword-face)
       " " (mapconcat (lambda (f) (propertize (concat "\"" f "\"")
                                         'font-lock-face 'font-lock-constant-face))
                      files-affected " ")
       ")\n"))
    (gptel-agent--confirm-overlay from (point) t)))
```
Agent often passes nil to `old-str` while keeping  `diffp` nil too. This keep the `description` uninitialized and cause 
```(propertize description 'font-lock-face 'font-lock-keyword-face)``` to explode later. Of cause we can just kind of fix it here. But I think the problem also stem from the instruction prompt for Edit tool is not good(not very clear about its diff mode like it is a afterthought), and also the dependence between diffp and old-str demands a higher bar of intelligence for the llm to get it right.

So I suggest to eliminating the diffp arg and let the old-str do it all, nil or empty old-str now signals it is in Diff mode.  and I edited the prompt accordingly, I don't think I am that good at writing prompt, so feel extra free to improve it.

I also think the 'Edit' tool could be separated to 'Replace' and 'Patch' to make it more straightforward for the agent to use it? idk if it will be even better though.