### PR TITLE
fix: match SKILL.md exactly

### DIFF
--- a/gptel-agent.el
+++ b/gptel-agent.el
@@ -215,7 +215,7 @@ Returns an alist of (agent-name . file-path)."
   (mapc (lambda (dir)
           (when (file-directory-p dir)
             (dolist (skill-file (directory-files-recursively
-                                 dir "SKILL\\.md" nil nil t))
+                                 dir "SKILL\\.md$" nil nil t))
               (pcase-let ((`(,name . ,skill-plist) ;loading only metadata
                            (gptel-agent-read-file skill-file nil t)))
                 ;; validating skill definition


### PR DESCRIPTION
'Cause gstacks has `SKILL.md.tmpl` files too.