### PR TITLE
Missing description can cause crash in gptel-agent--task-overlay

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -1381,7 +1381,7 @@ ARG-VALUES is a list: (type description prompt)"
                "\n" gptel-agent--hrule
                (propertize (concat (capitalize agent-type) " Task: ")
                            'face 'font-lock-escape-face)
-               (propertize description 'face 'font-lock-doc-face)
+               (propertize (or description "(no description)") 'face 'font-lock-doc-face)
                (propertize
                 " " 'display
                 (if (and (display-graphic-p) (fboundp 'string-pixel-width))


### PR DESCRIPTION
Crash is (wrong-type-argument stringp nil): when the model invokes the "Agent" tool without supplying the (schema-required) `description` argument.  The schema is not enforced on the client side, so a missing description trickles down into `propertize` and breaks the whole response. Default it instead so the call survives.