### PR TITLE
Fix typo in documentation for globbing tool

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -1734,7 +1734,7 @@ Consider using the more granular tools \"Insert\" or \"Edit\" first."
 - Returns matching file paths at all depths sorted by modification time.
   Limit the depth of the search by providing the `depth` argument.
 - When you are doing an open ended search that may require multiple rounds
-  of globbing and grepping, use the \"task\" tool instead
+  of globbing and grepping, use the \"Agent\" tool instead
 - You can call multiple tools in a single response.  It is always better to
   speculatively perform multiple searches in parallel if they are potentially useful."
  :function #'gptel-agent--glob


### PR DESCRIPTION
Since in gptel-agent, we only have Agent tool, no task tool.