### PR TITLE
Remove max-count option from gptel-agent--grep due to it's not supported by git-grep.

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -1132,7 +1132,6 @@ this tool cannot be used")))))
                                "--no-color"
                                (and (natnump context-lines)
                                     (format "-C%d" context-lines))
-                               "--max-count=1000"
                                "--untracked"
                                "-P" regex
                                "--")


### PR DESCRIPTION
git-grep does not support this option.