### PR TITLE
gptel-agent-tools: Use noninteractive url-retrieve

### DIFF
--- a/gptel-agent-tools.el
+++ b/gptel-agent-tools.el
@@ -288,6 +288,7 @@ passed to URL-CB.  FAILED-MSG is a fragment used for messaging.  Handles
 cleanup."
   (let* ((timeout 30) timer done
          (inherit-process-coding-system t)
+         (url-request-noninteractive t)
          (proc-buffer
           (url-retrieve
            url (lambda (status)


### PR DESCRIPTION
Currently, when WebFetch tool encounters HTTP 401 code (authorization required, but also some sites using CAPTCHA), or untrusted TLS certificates, it results in minibuffer prompt popping up, and tool waiting for timeout in `gptel-agent--fetch-with-timeout`. This in unproductive, especially when agent running unsupervised.

Fix this, by setting `url-request-noninteractive` to `t` for all agent requests.